### PR TITLE
Add CacheDirectory parameter to systemd unit file

### DIFF
--- a/apt-cacher-rs.service
+++ b/apt-cacher-rs.service
@@ -11,6 +11,7 @@ ExecStart=/usr/local/bin/apt-cacher-rs --skip-log-timestamp
 User=apt-cacher-rs
 
 # Hardening
+CacheDirectory=apt-cacher-rs
 CapabilityBoundingSet=
 LockPersonality=yes
 MemoryDenyWriteExecute=yes


### PR DESCRIPTION
The CacheDirectory parameter was added because Systemd would otherwise only allow read-only access to the /var/cache/apt-cacher-rs directory due to ProtectSystem=strict. It also causes Systemd to automatically create the directory with the appropriate permissions if it doesn't exist.