### PR TITLE
Delay start of apt-cacher-rs until the DNS resolver is available

### DIFF
--- a/debian/apt-cacher-rs.service
+++ b/debian/apt-cacher-rs.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=apt repository cache
-After=network.target
+After=network.target nss-lookup.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
Systemd now waits until the DNS resolver is ready before starting apt-cacher-rs. This prevents false-negative hostname caching when apt-cacher-rs is used very early during system boot.