### PR TITLE
Allow more open file descriptors via systemd

### DIFF
--- a/debian/apt-cacher-rs.service
+++ b/debian/apt-cacher-rs.service
@@ -11,6 +11,7 @@ User=apt-cacher-rs
 # Hardening
 CacheDirectory=apt-cacher-rs
 CapabilityBoundingSet=
+LimitNOFILE=16384
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=yes


### PR DESCRIPTION
Prevent running out of file descriptors when many files need to be downloaded in parallel.