### PR TITLE
Try to downgrade upstream mirror connections to http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "coarsetime",
  "console-subscriber",
  "futures-util",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ clap = { version = "4.5.1", features = ["derive"] }
 coarsetime = "0.1.36"
 console-subscriber = { version = "0.5", optional = true }
 futures-util = "0.3.30"
+http = "1.3.1"
 http-body-util = "0.1.0"
 hyper = { version = "1.2.0", features = ["full"] }
 hyper-rustls = { version = "0.27", optional = true }

--- a/debian/apt-cacher-rs.conf
+++ b/debian/apt-cacher-rs.conf
@@ -57,6 +57,12 @@
 #   allowed_mirrors = [ 'deb.debian.org', '*.ubuntu.com' ]
 #allowed_mirrors = []
 
+# List of mirrors where downgrading a https URI to a http URI is permitted.
+# Note that by default no mirrors are allowed.
+# Example:
+#   https_downgrading_mirrors = [ 'deb.debian.org', '*.ubuntu.com' ]
+#https_downgrading_mirrors = []
+
 # List of clients permitted to use the proxy.
 # If no clients are listed no restrictions are applied.
 # Note that localhost is not implicitly allowed.

--- a/dev.conf
+++ b/dev.conf
@@ -13,6 +13,7 @@ disk_quota = '3000M'
 min_download_rate = '500k'
 aliases = [ [ 'deb.debian.org' , [ 'ftp.ca.debian.org' ] ] ]
 allowed_mirrors = [ '*.debian.org', 'download.vscodium.com', 'apt.llvm.org' ]
+#https_downgrading_mirrors = []
 allowed_proxy_clients = [ '192.168.0.0/16', '127.0.0.1', '::1' ]
 allowed_webif_clients = [ '192.168.0.0/16', '127.0.0.1', '::1' ]
 https_tunnel_enabled = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,6 +265,10 @@ pub(crate) struct Config {
     #[serde(default = "default_allowed_mirrors")]
     pub(crate) allowed_mirrors: Vec<ConfigDomainName>,
 
+    /// List of mirrors to enable https to http downgrading.
+    #[serde(default = "default_https_downgrading_mirrors")]
+    pub(crate) https_downgrading_mirrors: Vec<ConfigDomainName>,
+
     /// List of clients permitted to use the proxy.
     /// Empty means all clients are allowed.
     #[serde(default = "default_allowed_proxy_clients")]
@@ -515,6 +519,10 @@ const fn default_allowed_mirrors() -> Vec<ConfigDomainName> {
     Vec::new()
 }
 
+const fn default_https_downgrading_mirrors() -> Vec<ConfigDomainName> {
+    Vec::new()
+}
+
 const fn default_disk_quota() -> Option<NonZero<u64>> {
     DEFAULT_DISK_QUOTA
 }
@@ -666,9 +674,10 @@ impl Config {
             database_slow_timeout: DEFAULT_DATABASE_SLOW_TIMEOUT,
             http_timeout: DEFAULT_HTTP_TIMEOUT,
             buffer_size: DEFAULT_BUF_SIZE,
-            aliases: Vec::new(),
-            allowed_mirrors: Vec::new(),
-            disk_quota: None,
+            aliases: default_aliases(),
+            allowed_mirrors: default_allowed_mirrors(),
+            https_downgrading_mirrors: default_https_downgrading_mirrors(),
+            disk_quota: default_disk_quota(),
             allowed_proxy_clients: Vec::new(),
             allowed_webif_clients: None,
             https_tunnel_enabled: true,
@@ -774,6 +783,7 @@ impl Config {
         }
 
         self.allowed_mirrors.sort();
+        self.https_downgrading_mirrors.sort();
         self.https_tunnel_allowed_ports.sort();
         self.https_tunnel_allowed_mirrors.sort();
 

--- a/src/task_cleanup.rs
+++ b/src/task_cleanup.rs
@@ -22,7 +22,7 @@ use crate::{
     deb_mirror::{Mirror, UriFormat},
     global_config,
     humanfmt::HumanFmt,
-    info_once, process_cache_request, task_cache_scan,
+    info_once, is_host_https_downgrade_permitted, process_cache_request, task_cache_scan,
 };
 
 async fn body_to_file(
@@ -169,6 +169,7 @@ async fn get_package_file(
         let conn_details = ConnectionDetails {
             client: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
             mirror: mirror.clone(),
+            downgrade_https: is_host_https_downgrade_permitted(&mirror.host),
             aliased_host: None,
             debname: format!(
                 "{distribution}_{component}_{architecture}_Packages{}",


### PR DESCRIPTION
When the upstream mirror only supports http enable downgrading the connection to http for permitted hosts.