### PR TITLE
Add support for caching unpacked Packages files

### DIFF
--- a/src/deb_mirror.rs
+++ b/src/deb_mirror.rs
@@ -208,7 +208,7 @@ pub(crate) fn parse_request_path(path: &str) -> Option<ResourceFile<'_>> {
                 distribution,
                 filename,
             });
-        } else if filename == "Packages.gz" || filename == "Packages.xz" {
+        } else if filename == "Packages.gz" || filename == "Packages.xz" || filename == "Packages" {
             let architecture = parts.next()?;
             let component = parts.next()?;
             let distribution = parts.next()?;


### PR DESCRIPTION
Add "Packages" file to the recognized / cached files as apt clients sometimes download the unpacked file instead of using Packages.gz or Packages.xz.