### PR TITLE
Rework partial download handling

### DIFF
--- a/src/guards.rs
+++ b/src/guards.rs
@@ -39,7 +39,7 @@ impl<'a> InitBarrier<'a> {
     }
 
     pub(crate) async fn finished(mut self, path: PathBuf) {
-        let data = self.data.take().expect("finished() is a sink");
+        let data = self.data.take().expect("every sink consumes the instance");
 
         *data.status.write().await = ActiveDownloadStatus::Finished(path);
         data.active_downloads.remove(data.mirror, data.debname);
@@ -51,7 +51,7 @@ impl<'a> InitBarrier<'a> {
         content_length: ContentLength,
         quota_reservation: Option<QuotaReservation>,
     ) -> DownloadBarrier {
-        let data = self.data.take().expect("download() is a sink");
+        let data = self.data.take().expect("every sink consumes the instance");
 
         let (tx, rx) = tokio::sync::watch::channel(());
 
@@ -68,6 +68,22 @@ impl<'a> InitBarrier<'a> {
                 bytes_since_ping: 0,
             }),
         }
+    }
+
+    #[must_use]
+    pub(crate) fn mirror(&self) -> &Mirror {
+        self.data
+            .as_ref()
+            .expect("every sink consumes the instance")
+            .mirror
+    }
+
+    #[must_use]
+    pub(crate) fn debname(&self) -> &str {
+        self.data
+            .as_ref()
+            .expect("every sink consumes the instance")
+            .debname
     }
 }
 
@@ -134,7 +150,7 @@ impl DownloadBarrier {
         let data = self
             .data
             .as_mut()
-            .expect("data is only extracted in a sink");
+            .expect("every sink consumes the instance");
         data.bytes_since_ping = data.bytes_since_ping.saturating_add(bytes);
         if data.bytes_since_ping >= PING_BATCH_THRESHOLD {
             data.internal_ping();
@@ -142,14 +158,14 @@ impl DownloadBarrier {
     }
 
     pub(crate) async fn abort_with_reason(mut self, reason: AbortReason) {
-        let data = self.data.take().expect("abort_with_reason() is a sink");
+        let data = self.data.take().expect("every sink consumes the instance");
 
         *data.status.write().await = ActiveDownloadStatus::Aborted(reason);
         data.active_downloads.remove(&data.mirror, &data.debname);
     }
 
     pub(crate) async fn begin_rename(mut self) -> RenameBarrier {
-        let mut data = self.data.take().expect("begin_rename() is a sink");
+        let mut data = self.data.take().expect("every sink consumes the instance");
 
         // Flush pending notification before dropping the sender, so
         // receivers can read the tail of the file before seeing the
@@ -206,9 +222,9 @@ pub(crate) struct RenameBarrier {
 
 impl RenameBarrier {
     pub(crate) fn release(mut self, path: PathBuf, bytes_received: u64) {
-        let mut data = self.data.take().expect("release() is a sink");
+        let mut data = self.data.take().expect("every sink consumes the instance");
 
-        if let Some(reservation) = data.quota_reservation.take() {
+        if let Some(reservation) = data.quota_reservation {
             reservation.finalize(bytes_received);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1950,7 +1950,7 @@ async fn download_file(
         match tokio::fs::rename(&outpath, &dest_file_path).await {
             Ok(()) => {
                 // Defuse the TempPath - the file has been successfully renamed
-                TempPath::into_inner(outpath);
+                TempPath::defuse(outpath);
 
                 let total_bytes = resume_offset + bytes;
                 rbarrier.release(dest_file_path, total_bytes);
@@ -2601,16 +2601,10 @@ async fn serve_new_file(
     let mut resume_offset: u64 = 0;
     let mut resume_expected_total: Option<u64> = None;
     let mut resume_if_range: Option<String> = None;
-    let mut partial_file: Option<tokio::fs::File> = None;
-    let mut partial_file_guard = if conn_details.cached_flavor == CachedFlavor::Permanent
+    let mut partial = if conn_details.cached_flavor == CachedFlavor::Permanent
         && matches!(cfstate, CacheFileStat::New)
     {
-        let pp = utils::partial_path(
-            &global_config().cache_directory,
-            &conn_details.mirror,
-            &conn_details.debname,
-        );
-        match utils::open_partial_file(&pp, &ibarrier).await {
+        match utils::open_partial_file(&ibarrier).await {
             Ok((file, size, _mtime, guard)) if size > 0 => {
                 // Only attempt resume when the partial carries a strong upstream
                 // ETag.  RFC 9110 §8.8.2.2 requires a strong validator for If-Range
@@ -2623,17 +2617,16 @@ async fn serve_new_file(
                 //
                 // `read_etag` rejects weak ETags, so any value returned here is a
                 // strong validator per RFC 9110 §8.8.3.
-                let upstream_identifier = read_etag(&file, &pp);
+                let upstream_identifier = read_etag(&file, &guard);
                 if let Some(if_range) = upstream_identifier {
                     resume_offset = size;
-                    resume_expected_total = xattr_helpers::read_expected_size(&file, &pp);
+                    resume_expected_total = xattr_helpers::read_expected_size(&file, &guard);
                     resume_if_range = Some(if_range);
                     info!(
                         "Found partial download ({} bytes) for {} from mirror {}, will attempt resume",
                         resume_offset, conn_details.debname, conn_details.mirror
                     );
-                    partial_file = Some(file);
-                    Some(guard)
+                    utils::PartialDownload::Resumable { file, guard }
                 } else {
                     // No strong validator stored (no upstream ETag, filesystem
                     // without xattr support, or only Last-Modified available) —
@@ -2643,15 +2636,14 @@ async fn serve_new_file(
                         conn_details.debname, conn_details.mirror
                     );
                     drop(file);
-                    guard.remove().await;
-                    Some(utils::TempPath::new(pp, true))
+                    utils::PartialDownload::Fresh(guard.renew().await)
                 }
             }
             Ok((_file, _size, _mtime, guard)) => {
                 // Zero-byte partial — treat as no partial
-                Some(guard)
+                utils::PartialDownload::Fresh(guard)
             }
-            Err(err) => {
+            Err((err, guard)) => {
                 if err.kind() != std::io::ErrorKind::NotFound {
                     error!(
                         "Failed to open partial file for {} from mirror {}:  {err}",
@@ -2659,11 +2651,11 @@ async fn serve_new_file(
                     );
                 }
                 // File doesn't exist or can't be opened — proceed without resume
-                Some(utils::TempPath::new(pp, true))
+                utils::PartialDownload::Fresh(guard)
             }
         }
     } else {
-        None
+        utils::PartialDownload::Volatile
     };
 
     let fwd_request = build_fwd_request(
@@ -2774,35 +2766,6 @@ async fn serve_new_file(
         );
     }
 
-    // Helper: discard the stale partial file and re-create the guard so a fresh download
-    // can still be resumed if it fails mid-stream.
-    let discard_partial = |partial_file: &mut Option<tokio::fs::File>,
-                           partial_file_guard: &mut Option<utils::TempPath>,
-                           resume_offset: &mut u64,
-                           resume_expected_total: &mut Option<u64>,
-                           conn_details: &ConnectionDetails| {
-        *partial_file = None; // drop the held file handle before removing
-        let guard = partial_file_guard.take();
-        let cached_flavor = conn_details.cached_flavor;
-        let mirror = conn_details.mirror.clone();
-        let debname = conn_details.debname.clone();
-        *resume_offset = 0;
-        *resume_expected_total = None;
-        async move {
-            if let Some(guard) = guard {
-                guard.remove().await;
-            }
-            // Re-create the guard at the deterministic partial path so this fresh download
-            // can still be resumed if it fails mid-stream.
-            if cached_flavor == CachedFlavor::Permanent {
-                let pp = utils::partial_path(&global_config().cache_directory, &mirror, &debname);
-                Some(utils::TempPath::new(pp, true))
-            } else {
-                None
-            }
-        }
-    };
-
     // Handle resume: if we sent Range and got 200 (server ignores Range) or 416
     // (partial is stale), discard partial and start fresh.
     let needs_retry = if resume_offset > 0 && fwd_response.status() == StatusCode::OK {
@@ -2810,28 +2773,18 @@ async fn serve_new_file(
             "Server returned 200 instead of 206 for resume of {} from mirror {}, starting fresh",
             conn_details.debname, conn_details.mirror
         );
-        partial_file_guard = discard_partial(
-            &mut partial_file,
-            &mut partial_file_guard,
-            &mut resume_offset,
-            &mut resume_expected_total,
-            &conn_details,
-        )
-        .await;
+        partial.discard_resume().await;
+        resume_offset = 0;
+        resume_expected_total = None;
         false
     } else if resume_offset > 0 && fwd_response.status() == StatusCode::RANGE_NOT_SATISFIABLE {
         warn!(
             "Server returned 416 for resume of {} from mirror {} (partial {} bytes), discarding stale partial",
             conn_details.debname, conn_details.mirror, resume_offset
         );
-        partial_file_guard = discard_partial(
-            &mut partial_file,
-            &mut partial_file_guard,
-            &mut resume_offset,
-            &mut resume_expected_total,
-            &conn_details,
-        )
-        .await;
+        partial.discard_resume().await;
+        resume_offset = 0;
+        resume_expected_total = None;
         true
     } else if resume_offset > 0 && fwd_response.status() == StatusCode::PARTIAL_CONTENT {
         // Validate Content-Range before proceeding: if the server returned 206 but the
@@ -2860,14 +2813,9 @@ async fn serve_new_file(
                 "Invalid or mismatched Content-Range in 206 for {} from mirror {}, discarding partial and retrying fresh",
                 conn_details.debname, conn_details.mirror
             );
-            partial_file_guard = discard_partial(
-                &mut partial_file,
-                &mut partial_file_guard,
-                &mut resume_offset,
-                &mut resume_expected_total,
-                &conn_details,
-            )
-            .await;
+            partial.discard_resume().await;
+            resume_offset = 0;
+            resume_expected_total = None;
             true
         }
     } else {
@@ -3115,18 +3063,12 @@ async fn serve_new_file(
     // Create/open the output file: partial path for permanent files, random temp for volatile.
     // Defuse the guard once we take ownership of the partial path — from here on, the
     // download's own TempPath (keep_on_drop: true) manages the file lifetime.
-    let (outfile, outpath) = if resume_offset > 0 {
-        // Resume: use the file already opened during the partial-file check.
-        // The file handle has been held open since the check, so no TOCTOU race.
-        let mut file = partial_file
-            .take()
-            .expect("partial_file set when resume_offset > 0");
-        let guard = partial_file_guard
-            .take()
-            .expect("partial_file_guard set when resume_offset > 0");
-        // Verify the file size matches expectations (should always hold since
-        // we've held the fd open, but check as defense-in-depth).
-        {
+    let (outfile, outpath) = match partial {
+        utils::PartialDownload::Resumable { mut file, guard } => {
+            // Resume: use the file already opened during the partial-file check.
+            // The file handle has been held open since the check, so no TOCTOU race.
+            // Verify the file size matches expectations (should always hold since
+            // we've held the fd open, but check as defense-in-depth).
             use tokio::io::AsyncSeekExt as _;
             let current_size = file.seek(std::io::SeekFrom::End(0)).await.unwrap_or(0);
             if current_size != resume_offset {
@@ -3135,31 +3077,38 @@ async fn serve_new_file(
                 );
                 return quick_response(StatusCode::INTERNAL_SERVER_ERROR, "Cache Access Failure");
             }
+            (file, guard)
         }
-        (file, guard)
-    } else if let Some(guard) = partial_file_guard.take() {
-        // Fresh permanent download: create at deterministic partial path
-        let pp = guard.into_inner();
-        match utils::create_partial_file(&pp, 0o640).await {
-            Ok((f, p)) => (f, p),
-            Err(err) => {
-                error!("Error creating partial file `{}`:  {err}", pp.display());
-                return quick_response(StatusCode::INTERNAL_SERVER_ERROR, "Cache Access Failure");
+        utils::PartialDownload::Fresh(guard) => {
+            // Fresh permanent download: create at deterministic partial path
+            match utils::create_partial_file(guard, 0o640).await {
+                Ok((f, p)) => (f, p),
+                Err((err, path)) => {
+                    error!("Error creating partial file `{}`:  {err}", path.display());
+                    return quick_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Cache Access Failure",
+                    );
+                }
             }
         }
-    } else {
-        // Volatile file: random temp file
-        let tmppath: PathBuf = [&global_config().cache_directory, Path::new("tmp"), filename]
-            .iter()
-            .collect();
-        match tokio_tempfile(&tmppath, 0o640).await {
-            Ok((f, p)) => (f, p),
-            Err(err) => {
-                error!(
-                    "Error creating temporary file `{}`:  {err}",
-                    tmppath.display()
-                );
-                return quick_response(StatusCode::INTERNAL_SERVER_ERROR, "Cache Access Failure");
+        utils::PartialDownload::Volatile => {
+            // Volatile file: random temp file
+            let tmppath: PathBuf = [&global_config().cache_directory, Path::new("tmp"), filename]
+                .iter()
+                .collect();
+            match tokio_tempfile(&tmppath, 0o640).await {
+                Ok((f, p)) => (f, p),
+                Err(err) => {
+                    error!(
+                        "Error creating temporary file `{}`:  {err}",
+                        tmppath.display()
+                    );
+                    return quick_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Cache Access Failure",
+                    );
+                }
             }
         }
     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,11 +7,7 @@ use std::{
 use log::{debug, error};
 use rand::{RngExt as _, distr::Alphanumeric, rngs::SmallRng};
 
-use crate::{
-    Never,
-    deb_mirror::{self, Mirror},
-    guards::InitBarrier,
-};
+use crate::{Never, deb_mirror, global_config, guards::InitBarrier};
 
 /// Compile-time macro for creating a `NonZero` value, panicking if the value is zero.
 #[macro_export]
@@ -37,6 +33,39 @@ macro_rules! static_assert {
     };
 }
 
+/// Tri-state of an in-progress download's partial-file handling.
+///
+/// - `Volatile`: non-permanent cache flavor — no partial-file semantics; caller creates a
+///   random temp file for the download.
+/// - `Fresh`: permanent cache flavor with no valid existing partial; the guard reserves
+///   the deterministic partial path so a failed download can be resumed on the next attempt.
+/// - `Resumable`: permanent cache flavor with an existing valid partial whose file handle
+///   has been held open since the size/ETag check (avoiding TOCTOU); caller resumes from
+///   `file`'s current offset.
+pub(crate) enum PartialDownload {
+    Volatile,
+    Fresh(TempPath),
+    Resumable {
+        file: tokio::fs::File,
+        guard: TempPath,
+    },
+}
+
+impl PartialDownload {
+    /// Downgrade a `Resumable` state to `Fresh` by removing the stale partial file and
+    /// re-creating the guard for the same path.  No-op for `Fresh` and `Volatile`.
+    pub(crate) async fn discard_resume(&mut self) {
+        *self = match std::mem::replace(self, Self::Volatile) {
+            Self::Volatile => Self::Volatile,
+            Self::Fresh(guard) => Self::Fresh(guard),
+            Self::Resumable { file, guard } => {
+                drop(file);
+                Self::Fresh(guard.renew().await)
+            }
+        };
+    }
+}
+
 /// A temporary file-path guard that automatically deletes the underlying file when dropped.
 ///
 /// When `keep_on_drop` is set to `true`, the file is preserved on drop instead of being deleted.
@@ -47,25 +76,37 @@ pub(crate) struct TempPath {
 }
 
 impl TempPath {
-    /// Create a new `TempPath` guard for an existing file.
-    pub(crate) fn new(path: PathBuf, keep_on_drop: bool) -> Self {
-        Self {
-            path: Some(path),
-            keep_on_drop,
-        }
-    }
-
     /// Defuse the temporary path guard, returning the underlying `PathBuf`.
-    pub(crate) fn into_inner(mut self) -> PathBuf {
+    pub(crate) fn defuse(mut self) -> PathBuf {
         std::mem::take(&mut self.path).expect("path has not been destructed yet")
     }
 
     /// Force deletion of the underlying file regardless of `keep_on_drop`.
-    pub(crate) async fn remove(mut self) {
-        if let Some(path) = self.path.take()
-            && let Err(err) = tokio::fs::remove_file(&path).await
-        {
-            log::warn!("Failed to remove partial file `{}`:  {err}", path.display());
+    async fn remove(mut self) -> PathBuf {
+        let path = std::mem::take(&mut self.path).expect("path has not been destructed yet");
+
+        if let Err(err) = tokio::fs::remove_file(&path).await {
+            let level = if err.kind() == std::io::ErrorKind::NotFound {
+                log::Level::Warn
+            } else {
+                log::Level::Error
+            };
+            log::log!(
+                level,
+                "Failed to remove partial file `{}`:  {err}",
+                path.display()
+            );
+        }
+
+        path
+    }
+
+    /// Remove the underlying file and return a fresh `TempPath` guarding the same path
+    /// with `keep_on_drop = true` so a retried download can still be resumed on failure.
+    pub(crate) async fn renew(self) -> Self {
+        Self {
+            path: Some(self.remove().await),
+            keep_on_drop: true,
         }
     }
 }
@@ -168,23 +209,6 @@ pub(crate) async fn tokio_tempfile(
     }
 }
 
-/// Compute a deterministic path for storing a partial download.
-///
-/// Returns `{cache_dir}/{mirror_cache_path}/tmp/{debname}.partial`.
-/// Uses the mirror's own cache directory to avoid collisions between mirrors.
-pub(crate) fn partial_path(cache_dir: &Path, mirror: &Mirror, debname: &str) -> PathBuf {
-    let mirror_dir = deb_mirror::mirror_cache_path_impl(&mirror.host, mirror.port, &mirror.path);
-    let filename = format!("{debname}.partial");
-    let filename = Path::new(&filename);
-    assert!(
-        filename.is_relative(),
-        "path construction must not contain absolute components"
-    );
-    [cache_dir, mirror_dir.as_path(), Path::new("tmp"), filename]
-        .iter()
-        .collect()
-}
-
 /// Open an existing partial file for writing at the end, returning the file, its current size,
 /// the file's modification time, and a `TempPath` guard with `keep_on_drop: true`.
 ///
@@ -194,60 +218,88 @@ pub(crate) fn partial_path(cache_dir: &Path, mirror: &Mirror, debname: &str) -> 
 /// By opening the file and querying size + mtime from the same file handle, this avoids
 /// TOCTOU races between a separate `metadata()` check and a later `open()`.
 pub(crate) async fn open_partial_file(
-    path: &Path,
-    _ibarrier: &InitBarrier<'_>, // ensures the file is opened while the init barrier is held
-) -> Result<(tokio::fs::File, u64, SystemTime, TempPath), tokio::io::Error> {
+    ibarrier: &InitBarrier<'_>,
+) -> Result<(tokio::fs::File, u64, SystemTime, TempPath), (tokio::io::Error, TempPath)> {
     use tokio::io::AsyncSeekExt as _;
 
-    let mut file = tokio::fs::File::options()
-        .write(true)
-        .read(true)
-        .open(path)
-        .await?;
+    async fn file_ops(path: &Path) -> Result<(tokio::fs::File, u64, SystemTime), tokio::io::Error> {
+        let mut file = tokio::fs::File::options()
+            .write(true)
+            .read(true)
+            .open(path)
+            .await?;
 
-    // Seek to the end so subsequent writes append correctly.
-    let size = file.seek(std::io::SeekFrom::End(0)).await?;
+        // Seek to the end so subsequent writes append correctly.
+        let size = file.seek(std::io::SeekFrom::End(0)).await?;
 
-    let mtime = file
-        .metadata()
-        .await?
-        .modified()
-        .expect("Platform should support modification timestamps via setup check");
+        let mtime = file
+            .metadata()
+            .await?
+            .modified()
+            .expect("Platform should support modification timestamps via setup check");
 
-    Ok((
-        file,
-        size,
-        mtime,
-        TempPath {
-            path: Some(path.to_path_buf()),
-            keep_on_drop: true,
-        },
-    ))
+        Ok((file, size, mtime))
+    }
+
+    let mirror = ibarrier.mirror();
+    let mirror_dir = deb_mirror::mirror_cache_path_impl(&mirror.host, mirror.port, &mirror.path);
+    let filename = format!("{debname}.partial", debname = ibarrier.debname());
+    let filename = Path::new(&filename);
+    assert!(
+        filename.is_relative(),
+        "path construction must not contain absolute components"
+    );
+    let path: PathBuf = [
+        &global_config().cache_directory,
+        mirror_dir.as_path(),
+        Path::new("tmp"),
+        filename,
+    ]
+    .iter()
+    .collect();
+
+    let guard = TempPath {
+        path: Some(path),
+        keep_on_drop: true,
+    };
+    match file_ops(&guard).await {
+        Ok((file, size, mtime)) => Ok((file, size, mtime, guard)),
+        Err(e) => Err((e, guard)),
+    }
 }
 
 /// Create a new file at the given deterministic partial path, returning the file and a
 /// `TempPath` guard with `keep_on_drop: true`.
 pub(crate) async fn create_partial_file(
-    path: &Path,
+    guard: TempPath,
     mode: u32,
-) -> Result<(tokio::fs::File, TempPath), tokio::io::Error> {
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
+) -> Result<(tokio::fs::File, TempPath), (tokio::io::Error, PathBuf)> {
+    async fn file_ops(path: &Path, mode: u32) -> Result<tokio::fs::File, tokio::io::Error> {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        tokio::fs::File::options()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .read(true)
+            .mode(mode)
+            .open(path)
+            .await
     }
 
-    let file = tokio::fs::File::options()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .read(true)
-        .mode(mode)
-        .open(path)
-        .await?;
+    let path = guard.defuse();
+
+    let file = match file_ops(&path, mode).await {
+        Ok(file) => file,
+        Err(err) => return Err((err, path)),
+    };
 
     Ok((
         file,
         TempPath {
-            path: Some(path.to_path_buf()),
+            path: Some(path),
             keep_on_drop: true,
         },
     ))


### PR DESCRIPTION
Make use of the rust type system to avoid invalid states and clean up the caller code.