### PR TITLE
sendfile: serve web interface directly instead of falling back to hyper

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3480,7 +3480,9 @@ async fn pre_process_client_request(
                 }
             }
 
-            return serve_web_interface(req, &appstate).await;
+            return serve_web_interface(req.uri(), &appstate)
+                .await
+                .into_hyper_response();
         };
 
     let requested_port = match req.uri().port_u16() {

--- a/src/sendfile_conn.rs
+++ b/src/sendfile_conn.rs
@@ -24,20 +24,22 @@ use crate::error::{ErrorReport, errno_to_io_error};
 use crate::http_etag::{if_none_match, read_etag};
 use crate::http_helpers::{
     ConnectionAction, ConnectionVersion, ResponseHeaders, find_header, find_header_end,
-    write_304_response, write_416_response, write_invalid_response, write_response_headers,
+    write_304_response, write_416_response, write_all_to_stream, write_invalid_response,
+    write_response_headers,
 };
 use crate::http_last_modified::read_last_modified;
 use crate::http_range::{
-    HttpDate, ParsedRange, cache_file_http_date, compute_age, http_parse_range,
+    HttpDate, ParsedRange, cache_file_http_date, compute_age, format_http_date, http_parse_range,
 };
 use crate::humanfmt::HumanFmt;
 use crate::rate_checked_body::{InsufficientRate, RateCheckDirection, RateChecker};
 use crate::tcp_cork_guard::CorkGuard;
 use crate::{
-    ActiveDownloadStatus, AppState, CachedFlavor, ClientInfo, ConnectionDetails, ContentLength,
-    Never, VOLATILE_CACHE_MAX_AGE, authorize_cache_access, client_counter,
+    APP_NAME, ActiveDownloadStatus, AppState, CachedFlavor, ClientInfo, ConnectionDetails,
+    ContentLength, Never, VOLATILE_CACHE_MAX_AGE, authorize_cache_access, client_counter,
     content_type_for_cached_file, global_config, handle_hyper_connection, is_diff_request_path,
     metrics, static_assert, warn_once_or_debug, warn_once_or_info,
+    web_interface::{HTML_CSP, WebResponse, WebResponseKind, serve_web_interface},
 };
 
 /// Maximum size for HTTP request headers buffer (matches hyper's default of 8192).
@@ -267,6 +269,99 @@ async fn read_request_headers(
     }
 }
 
+/// Serve a local web-interface request directly from the sendfile path.
+///
+/// The hyper-based handler exists in `web_interface::serve_web_interface`; this
+/// wrapper invokes it and serializes the resulting `WebResponse`
+/// onto the raw `TcpStream` with handwritten headers, so webui responses look
+/// the same regardless of which connection backend served them.
+async fn serve_webui(
+    stream: &TcpStream,
+    uri: &http::Uri,
+    appstate: &AppState,
+    client: &ClientInfo,
+    conn_version: ConnectionVersion,
+    conn_action: ConnectionAction,
+) -> SendfileResult {
+    let cfg = global_config();
+    let allowed_webif_clients = cfg
+        .allowed_webif_clients
+        .as_ref()
+        .unwrap_or(&cfg.allowed_proxy_clients);
+    let client_ip = client.ip();
+    if !allowed_webif_clients.is_empty()
+        && !allowed_webif_clients
+            .iter()
+            .any(|ac| ac.contains(&client_ip))
+    {
+        warn_once_or_info!("Unauthorized web-interface access by client {client}");
+        return SendfileResult::Rejection {
+            status: StatusCode::FORBIDDEN,
+            conn_action,
+            msg: "Unauthorized client",
+        };
+    }
+
+    let response = serve_web_interface(uri, appstate).await;
+
+    if let Err(err) = write_webui_response(stream, conn_version, conn_action, response).await {
+        info!("Failed to write web-interface response to client {client}:  {err}");
+        return SendfileResult::AfterHeaderError;
+    }
+    SendfileResult::Served(conn_action)
+}
+
+/// Format and write a [`WebResponse`] onto the raw stream.
+///
+/// Mirrors the layout used by [`crate::http_helpers::write_response_headers`]:
+/// a single `format!` builds the entire status-line + headers block with named
+/// substitutions, so the wire bytes are easy to read alongside the hyper-side
+/// `WebResponse::into_hyper_response` constructor.
+async fn write_webui_response(
+    stream: &TcpStream,
+    conn_version: ConnectionVersion,
+    conn_action: ConnectionAction,
+    response: WebResponse,
+) -> std::io::Result<()> {
+    let date = format_http_date();
+    let content_type = response.content_type();
+    let body_len = response.body.len();
+    let status = response.status;
+
+    // Per-kind extra headers, kept in lockstep with `WebResponse::into_hyper_response`.
+    let extra_headers: String = match response.kind {
+        WebResponseKind::Html => format!(
+            "Cache-Control: no-store\r\n\
+             Content-Security-Policy: {HTML_CSP}\r\n\
+             X-Content-Type-Options: nosniff\r\n\
+             X-Frame-Options: DENY\r\n\
+             X-Robots-Tag: noindex\r\n\
+             Referrer-Policy: no-referrer\r\n",
+        ),
+        WebResponseKind::Static { .. } => String::from(
+            "Cache-Control: public, max-age=86400\r\n\
+             X-Content-Type-Options: nosniff\r\n",
+        ),
+        WebResponseKind::Error => String::new(),
+    };
+
+    let header = format!(
+        "{conn_version} {status}\r\n\
+         Server: {APP_NAME}\r\n\
+         Date: {date}\r\n\
+         Connection: {conn_action}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {body_len}\r\n\
+         {extra_headers}\
+         \r\n",
+    );
+
+    trace!("Outgoing web-interface response headers:\n{header}");
+    metrics::record_client_status(status);
+    write_all_to_stream(stream, header.as_bytes()).await?;
+    write_all_to_stream(stream, &response.body).await
+}
+
 /// Compute the connection action based on the request headers.
 #[must_use]
 fn compute_conn_action(
@@ -471,8 +566,9 @@ async fn try_sendfile_request(
                 msg: "Missing Host header",
             };
         }
-        // No authority means it's likely a direct request (web interface) - fall back
-        return SendfileResult::NotApplicable("no authority");
+        // No authority means it's a direct request to the local web interface.
+        let conn_action = compute_conn_action(&req, *conn_version, &client);
+        return serve_webui(stream, &uri, appstate, &client, *conn_version, conn_action).await;
     };
 
     let requested_host = match authorize_cache_access(&client, authority.host().to_string()) {

--- a/src/web_interface.rs
+++ b/src/web_interface.rs
@@ -8,16 +8,12 @@ use std::{
 
 use coarsetime::Instant;
 use hashbrown::HashMap;
-use http::{
-    Method,
-    header::{
-        CACHE_CONTROL, CONTENT_SECURITY_POLICY, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS,
-        X_FRAME_OPTIONS,
-    },
+use http::header::{
+    CACHE_CONTROL, CONTENT_SECURITY_POLICY, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS,
+    X_FRAME_OPTIONS,
 };
 use hyper::{
-    Request, Response, StatusCode,
-    body::Incoming,
+    Response, StatusCode,
     header::{CONNECTION, CONTENT_TYPE, DATE, SERVER},
 };
 use log::{debug, error, trace, warn};
@@ -32,7 +28,6 @@ use crate::{
     database_task::DB_TASK_QUEUE_SENDER,
     deb_mirror::VALID_DEB_EXTENSIONS,
     format_http_date, full_body, get_features, global_cache_quota, global_config, metrics,
-    quick_response,
     task_cleanup::{CLEANUP_INTERVAL_SECS, next_cleanup_epoch},
     tunnel_limiter::active_tunnels,
     uncacheables::{UNCACHEABLES_MAX, get_uncacheables},
@@ -1972,31 +1967,101 @@ fn build_dashboard_page(data: &DashboardData, options: QueryOptions) -> String {
     build_page("apt-cacher-rs web interface", body, options)
 }
 
-/// Build an HTML page response with standard security headers.
-fn html_response(html: String) -> Response<ProxyCacheBody> {
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(SERVER, APP_NAME)
-        .header(DATE, format_http_date())
-        .header(CONNECTION, "keep-alive")
-        .header(CONTENT_TYPE, "text/html; charset=utf-8")
-        .header(CACHE_CONTROL, "no-store")
-        // `style-src 'self'` permits the linked `/style.css` but blocks any
-        // `<style>` block or inline `style="..."` attribute. If a future
-        // change wants inline styles, it has to either move them into the
-        // stylesheet or extend the CSP — silent CSP rejections are easy to
-        // miss when only some users have devtools open.
-        .header(
-            CONTENT_SECURITY_POLICY,
-            "default-src 'none'; style-src 'self'; img-src 'self' data:; \
-             base-uri 'none'; form-action 'none'",
-        )
-        .header(X_CONTENT_TYPE_OPTIONS, "nosniff")
-        .header(X_FRAME_OPTIONS, "DENY")
-        .header("X-Robots-Tag", "noindex")
-        .header(REFERRER_POLICY, "no-referrer")
-        .body(full_body(html))
-        .expect("HTTP response is valid")
+/// Content-Security-Policy applied to every HTML page.
+///
+/// `style-src 'self'` permits the linked `/style.css` but blocks any `<style>`
+/// block or inline `style="..."` attribute. If a future change wants inline
+/// styles, it has to either move them into the stylesheet or extend the CSP —
+/// silent CSP rejections are easy to miss when only some users have devtools
+/// open.
+pub(crate) const HTML_CSP: &str = "default-src 'none'; style-src 'self'; img-src 'self' data:; \
+     base-uri 'none'; form-action 'none'";
+
+/// A response from the local web interface.
+///
+/// Carries enough information for the hyper backend to construct a
+/// `Response<ProxyCacheBody>` and for the sendfile backend to format the wire
+/// bytes by hand using `format!` (see `sendfile_conn::write_webui_response`).
+/// The two paths derive their headers from the same `WebResponse`, so clients
+/// see the same response regardless of which backend served the request.
+pub(crate) struct WebResponse {
+    pub(crate) status: StatusCode,
+    pub(crate) body: bytes::Bytes,
+    pub(crate) kind: WebResponseKind,
+}
+
+pub(crate) enum WebResponseKind {
+    /// Dashboard or logs page; served with `no-store` cache and full
+    /// security headers.
+    Html,
+    /// Static asset (CSS/SVG) with long-lived caching and `nosniff`.
+    Static { content_type: &'static str },
+    /// Plain-text error response.
+    Error,
+}
+
+impl WebResponse {
+    fn html(html: String) -> Self {
+        Self {
+            status: StatusCode::OK,
+            body: bytes::Bytes::from(html),
+            kind: WebResponseKind::Html,
+        }
+    }
+
+    fn static_resource(content_type: &'static str, content: &'static str) -> Self {
+        Self {
+            status: StatusCode::OK,
+            body: bytes::Bytes::from_static(content.as_bytes()),
+            kind: WebResponseKind::Static { content_type },
+        }
+    }
+
+    fn not_found(msg: &'static str) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            body: bytes::Bytes::from_static(msg.as_bytes()),
+            kind: WebResponseKind::Error,
+        }
+    }
+
+    pub(crate) fn content_type(&self) -> &'static str {
+        match self.kind {
+            WebResponseKind::Html => "text/html; charset=utf-8",
+            WebResponseKind::Static { content_type } => content_type,
+            WebResponseKind::Error => "text/plain; charset=utf-8",
+        }
+    }
+
+    /// Render this response as a `Response<ProxyCacheBody>` for the hyper path.
+    pub(crate) fn into_hyper_response(self) -> Response<ProxyCacheBody> {
+        let mut builder = Response::builder()
+            .status(self.status)
+            .header(SERVER, APP_NAME)
+            .header(DATE, format_http_date())
+            .header(CONNECTION, "keep-alive")
+            .header(CONTENT_TYPE, self.content_type());
+        match self.kind {
+            WebResponseKind::Html => {
+                builder = builder
+                    .header(CACHE_CONTROL, "no-store")
+                    .header(CONTENT_SECURITY_POLICY, HTML_CSP)
+                    .header(X_CONTENT_TYPE_OPTIONS, "nosniff")
+                    .header(X_FRAME_OPTIONS, "DENY")
+                    .header("X-Robots-Tag", "noindex")
+                    .header(REFERRER_POLICY, "no-referrer");
+            }
+            WebResponseKind::Static { .. } => {
+                builder = builder
+                    .header(CACHE_CONTROL, "public, max-age=86400")
+                    .header(X_CONTENT_TYPE_OPTIONS, "nosniff");
+            }
+            WebResponseKind::Error => {}
+        }
+        builder
+            .body(full_body(self.body))
+            .expect("HTTP response is valid")
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2004,70 +2069,41 @@ fn html_response(html: String) -> Response<ProxyCacheBody> {
 // ---------------------------------------------------------------------------
 
 #[must_use]
-pub(crate) async fn serve_web_interface(
-    req: Request<Incoming>,
-    appstate: &AppState,
-) -> Response<ProxyCacheBody> {
-    debug_assert_eq!(
-        req.method(),
-        Method::GET,
-        "caller filters out non-GET requests"
-    );
-
+pub(crate) async fn serve_web_interface(uri: &http::Uri, appstate: &AppState) -> WebResponse {
     metrics::WEBUI_REQUESTS.increment();
 
-    let location = req.uri().path();
+    let location = uri.path();
     debug!("Requested local web interface resource `{location}`");
 
-    let options = parse_query(req.uri().query());
+    let options = parse_query(uri.query());
 
     let response = match location {
         "/" => serve_dashboard(appstate, options).await,
         "/logs" => serve_logs(options).await,
-        "/style.css" => serve_stylesheet(),
-        "/favicon.svg" | "/favicon.ico" => serve_favicon(),
+        "/style.css" => WebResponse::static_resource("text/css; charset=utf-8", CSS),
+        "/favicon.svg" | "/favicon.ico" => {
+            WebResponse::static_resource("image/svg+xml", FAVICON_SVG)
+        }
         _ => {
-            debug!("Unknown local web interface resource: {req:?}");
-            quick_response(
-                StatusCode::NOT_FOUND,
-                "Local interface resource not available",
-            )
+            debug!("Unknown local web interface resource: {uri:?}");
+            WebResponse::not_found("Local interface resource not available")
         }
     };
 
-    trace!("Local web interface response:\n{response:?}");
+    trace!(
+        "Local web interface response: status={}, content-type={}, body={} bytes",
+        response.status,
+        response.content_type(),
+        response.body.len()
+    );
 
     response
 }
 
-async fn serve_dashboard(appstate: &AppState, options: QueryOptions) -> Response<ProxyCacheBody> {
+async fn serve_dashboard(appstate: &AppState, options: QueryOptions) -> WebResponse {
     let data = gather_dashboard_data(appstate).await;
     let html = build_dashboard_page(&data, options);
-    html_response(html)
-}
-
-fn serve_static_resource(
-    content_type: &'static str,
-    content: &'static str,
-) -> Response<ProxyCacheBody> {
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(SERVER, APP_NAME)
-        .header(DATE, format_http_date())
-        .header(CONNECTION, "keep-alive")
-        .header(CONTENT_TYPE, content_type)
-        .header(CACHE_CONTROL, "public, max-age=86400")
-        .header(X_CONTENT_TYPE_OPTIONS, "nosniff")
-        .body(full_body(content))
-        .expect("HTTP response is valid")
-}
-
-fn serve_favicon() -> Response<ProxyCacheBody> {
-    serve_static_resource("image/svg+xml", FAVICON_SVG)
-}
-
-fn serve_stylesheet() -> Response<ProxyCacheBody> {
-    serve_static_resource("text/css; charset=utf-8", CSS)
+    WebResponse::html(html)
 }
 
 // ---------------------------------------------------------------------------
@@ -2625,7 +2661,7 @@ async fn build_top_packages_table(database: &Database, view: TopPackagesView) ->
 // ---------------------------------------------------------------------------
 
 #[must_use]
-async fn serve_logs(options: QueryOptions) -> Response<ProxyCacheBody> {
+async fn serve_logs(options: QueryOptions) -> WebResponse {
     let ls = LOGSTORE.get().expect("initialized in main()");
 
     // HTML-escape every entry on the blocking pool: with a large
@@ -2673,7 +2709,7 @@ async fn serve_logs(options: QueryOptions) -> Response<ProxyCacheBody> {
             refresh_secs: None,
         },
     );
-    html_response(html)
+    WebResponse::html(html)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Web-interface requests (no authority in the request URI) used to bounce off the sendfile backend with NotApplicable("no authority"), pulling the connection into the hyper handler for the rest of its lifetime. Serve them in place instead: the new WebResponse type carries status, body, and a kind tag, and both backends derive their wire bytes from it — hyper via into_hyper_response(), sendfile via a hand-formatted format! block in write_webui_response that mirrors http_helpers::write_response_headers. The shared HTML_CSP constant keeps the two paths from drifting on the CSP value.