### PR TITLE
Allow overriding cache and database paths via CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".env", ".github/", ".gitignore", "dev.conf", "TODO"]
 
 [features]
 default = ["mmap", "tls_rustls", "sendfile"]
-container = ["tls_rustls", "hyper-rustls/webpki-roots"]
+webpki-roots = ["tls_rustls", "hyper-rustls/webpki-roots"]
 mmap = ["dep:memmap2"]
 sendfile = ["dep:httparse", "nix/zerocopy"]
 splice = ["sendfile", "nix/socket"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN apk add \
     build-base \
     cmake \
     pkgconf \
-    sqlite-dev \
-    xz-dev
+    xz-static
 
 RUN adduser \
     --disabled-password \
@@ -22,7 +21,7 @@ RUN adduser \
 WORKDIR /app
 COPY . .
 
-RUN cargo install --locked --root /out --path . --features container
+RUN cargo install --locked --root /out --path . --features webpki-roots
 
 # --- final image
 
@@ -36,4 +35,8 @@ COPY --from=builder /out/bin/apt-cacher-rs /app/apt-cacher-rs
 USER app:app
 VOLUME ["/data"]
 EXPOSE 3142/tcp
-CMD ["/app/apt-cacher-rs"]
+ENTRYPOINT ["/app/apt-cacher-rs", \
+            "--config-file=/app/apt-cacher-rs.conf", \
+            "--cache-path=/data/cache", \
+            "--database-path=/data/apt-cacher-rs.db"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -32,12 +32,24 @@ podman build -t apt-cacher-rs:dev -f Dockerfile .
 ```
 
 The image expects a `volume` mounted at */data* to store the database and cached files.
-You should also provide a configuration file via a mount on */app/apt-cacher-rs.conf*, since the default configuration does not permit any clients.
+You must also provide a configuration file via a mount on */app/apt-cacher-rs.conf*, since the default configuration does not permit any clients.
 For example you can start a container via:
 
 ```bash
 podman run -p 3142:3142/tcp --read-only --rm -v apt-cacher-rs-data:/data:nodev,noexec,nosuid -v /srv/apt-cacher-rs.conf:/app/apt-cacher-rs.conf:ro apt-cacher-rs:dev
 ```
+
+The image's `ENTRYPOINT` hard-codes `--config-file=/app/apt-cacher-rs.conf`, `--cache-path=/data/cache` and `--database-path=/data/apt-cacher-rs.db`; any extra arguments passed to `podman run` are appended after these flags.
+To use different paths, override the entrypoint via `--entrypoint`.
+
+## Command-line options
+
+The most relevant flags (see `apt-cacher-rs --help` for the full list):
+
+- `--config-file=<PATH>`: path to the configuration file (default */etc/apt-cacher-rs/apt-cacher-rs.conf*).
+  If the default file is missing the built-in defaults are used; a missing non-default file is an error.
+- `--cache-path=<PATH>`: overrides the `cache_directory` field from the configuration file (or its default).
+- `--database-path=<PATH>`: overrides the `database_path` field from the configuration file (or its default).
 
 ## How to use
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,21 +19,9 @@ use serde::Deserializer;
 
 use crate::nonzero;
 
-const DEFAULT_CACHE_DIR: &str = if cfg!(feature = "container") {
-    "/data/cache"
-} else {
-    "/var/cache/apt-cacher-rs"
-};
-pub(crate) const DEFAULT_CONFIGURATION_PATH: &str = if cfg!(feature = "container") {
-    "/app/apt-cacher-rs.conf"
-} else {
-    "/etc/apt-cacher-rs/apt-cacher-rs.conf"
-};
-pub(crate) const DEFAULT_DATABASE_PATH: &str = if cfg!(feature = "container") {
-    "/data/apt-cacher-rs.db"
-} else {
-    "/var/lib/apt-cacher-rs/apt-cacher-rs.db"
-};
+const DEFAULT_CACHE_DIR: &str = "/var/cache/apt-cacher-rs";
+pub(crate) const DEFAULT_CONFIGURATION_PATH: &str = "/etc/apt-cacher-rs/apt-cacher-rs.conf";
+pub(crate) const DEFAULT_DATABASE_PATH: &str = "/var/lib/apt-cacher-rs/apt-cacher-rs.db";
 
 const DEFAULT_BIND_ADDRESS: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
 const DEFAULT_BIND_PORT: NonZero<u16> = nonzero!(3142);
@@ -978,16 +966,30 @@ impl Config {
     }
 
     /// Load the configuration from the given file.
-    /// Return the loaded configuration, a flag whether default settings were used,
-    /// and a list of validation warnings.
-    pub(crate) fn new(file: &Path) -> anyhow::Result<(Self, bool, Vec<String>)> {
-        let content = match std::fs::read_to_string(file) {
-            Ok(c) => c,
+    /// Return the loaded configuration, a flag indicating whether the default
+    /// configuration file was not found and the built-in defaults were used
+    /// instead, and a list of validation warnings.
+    ///
+    /// When supplied, `cache_directory` overrides [`Self::cache_directory`]
+    /// and `database_path` overrides [`Self::database_path`], applied on top
+    /// of the values from the configuration file (or the built-in defaults
+    /// when no file is loaded). A non-default `file` that does not exist is
+    /// always an error, even when both overrides are supplied.
+    pub(crate) fn new(
+        file: &Path,
+        cache_directory: Option<PathBuf>,
+        database_path: Option<PathBuf>,
+    ) -> anyhow::Result<(Self, bool, Vec<String>)> {
+        let (mut config, fallback) = match std::fs::read_to_string(file) {
+            Ok(content) => (
+                toml::from_str::<Self>(&content).context("Failed to parse configuration")?,
+                false,
+            ),
             Err(err)
                 if err.kind() == std::io::ErrorKind::NotFound
                     && file == Path::new(DEFAULT_CONFIGURATION_PATH) =>
             {
-                return Ok((Self::default(), true, Vec::new()));
+                (Self::default(), true)
             }
             Err(err) => {
                 return Err(err)
@@ -995,11 +997,16 @@ impl Config {
             }
         };
 
-        let mut config: Self = toml::from_str(&content).context("Failed to parse configuration")?;
+        if let Some(path) = cache_directory {
+            config.cache_directory = path;
+        }
+        if let Some(path) = database_path {
+            config.database_path = path;
+        }
 
         let warnings = config.validate()?;
 
-        Ok((config, false, warnings))
+        Ok((config, fallback, warnings))
     }
 
     fn validate(&mut self) -> anyhow::Result<Vec<String>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4496,6 +4496,14 @@ struct Cli {
         value_name = "PATH"
     )]
     config_file: PathBuf,
+    /// Cache directory path; overrides `cache_directory` from the
+    /// configuration file (or the built-in default when no file is loaded)
+    #[arg(long, value_name = "PATH")]
+    cache_path: Option<PathBuf>,
+    /// Database file path; overrides `database_path` from the configuration
+    /// file (or the built-in default when no file is loaded)
+    #[arg(long, value_name = "PATH")]
+    database_path: Option<PathBuf>,
     /// Skip timestamp in log messages
     #[arg(long, default_value = "false")]
     skip_log_timestamp: bool,
@@ -4574,7 +4582,7 @@ pub(crate) fn global_cache_quota() -> &'static cache_quota::CacheQuota {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let args = Cli::parse();
+    let mut args = Cli::parse();
 
     let is_run_as_root = nix::unistd::geteuid().is_root();
 
@@ -4584,7 +4592,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         std::process::exit(1);
     }
 
-    let (config, cfg_fallback, config_warnings) = Config::new(&args.config_file)?;
+    let (config, cfg_fallback, config_warnings) = Config::new(
+        &args.config_file,
+        args.cache_path.take(),
+        args.database_path.take(),
+    )?;
 
     let output_log_level = args.log_level.unwrap_or(config.log_level);
     let output_log_file = args.log_file.as_ref().unwrap_or(&config.log_file);
@@ -4731,11 +4743,11 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 .install_default()
                 .expect("first and sole call should succeed");
 
-            #[cfg(feature = "container")]
+            #[cfg(feature = "webpki-roots")]
             let tls_config = rustls::ClientConfig::builder()
                 .with_webpki_roots()
                 .with_no_client_auth();
-            #[cfg(not(feature = "container"))]
+            #[cfg(not(feature = "webpki-roots"))]
             let tls_config = rustls::ClientConfig::builder()
                 .with_native_roots()
                 .inspect_err(|err| error!("Failed to load native roots:  {}", ErrorReport(err)))?

--- a/src/task_setup.rs
+++ b/src/task_setup.rs
@@ -1,5 +1,5 @@
 use anyhow::Context as _;
-use log::{Level, debug, error, log, warn};
+use log::{debug, error, info, warn};
 
 use crate::global_config;
 
@@ -26,12 +26,7 @@ pub(crate) fn task_setup() -> anyhow::Result<()> {
         .modified()
         .context("No file modification timestamp (mtime) support")?;
     if let Err(err) = mdata.created() {
-        #[cfg(feature = "container")]
-        let level = Level::Debug;
-        #[cfg(not(feature = "container"))]
-        let level = Level::Info;
-        log!(
-            level,
+        info!(
             "No file creation timestamp (btime) support, volatile file caching is limited:  {err}"
         );
     }


### PR DESCRIPTION
Replace the container-feature path overrides with --cache-directory and --database-path command-line options that override the configuration file values. Update the Dockerfile entrypoint to pass them.