### PR TITLE
ci: build deb package on tag and pre-upload

### DIFF
--- a/.github/workflows/release_deb.yml
+++ b/.github/workflows/release_deb.yml
@@ -1,8 +1,9 @@
 name: Release Debian Package
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build-deb:
@@ -36,5 +37,6 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
+          draft: true
           files: target/debian/*.deb
           fail_on_unmatched_files: true

--- a/TODO
+++ b/TODO
@@ -46,5 +46,6 @@ curl -i -L --http1.1 -H "user-agent: apt-cacher-rs/0.1.0" -H "host: apt.llvm.org
   13.  run `cargo publish --dry-run`
   14.  create release commit with changed version number in *Cargo.toml* and *Cargo.lock*
   15.  run `cargo publish`
-  16.  create and push git tag
-  17.  create Release on GitHub
+  16.  create git tag: `git tag -a -s -m "apt-cacher-rs release 0.0.0" v0.0.0`
+  17.  push git tag: `git push origin v0.0.0`
+  18.  create Release on GitHub


### PR DESCRIPTION
Running on release does not work with immutable releases.