### PR TITLE
client_counter: cover passthrough, error-relay, and demotion overlap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -883,6 +883,52 @@ where
     }
 }
 
+/// Body wrapper that holds a [`client_counter::ClientDownload`] for the lifetime
+/// of the body so paths without their own counter (passthrough, upstream
+/// error-body relay) still register in `ACTIVE_CLIENT_DOWNLOADS`. Forwards
+/// `Body` methods unchanged.
+#[pin_project]
+struct ClientCountedBody<B: Body> {
+    #[pin]
+    inner: B,
+    _counter: client_counter::ClientDownload,
+}
+
+impl<B: Body> ClientCountedBody<B> {
+    fn new(inner: B) -> Self {
+        Self {
+            inner,
+            _counter: client_counter::ClientDownload::new(),
+        }
+    }
+}
+
+impl<B> Body for ClientCountedBody<B>
+where
+    B: Body,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    #[inline]
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        self.project().inner.poll_frame(cx)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+}
+
 #[cfg(feature = "mmap")]
 const MMAP_FRAME_SIZE: usize = 2 * 1024 * 1024; // 2MiB
 
@@ -2808,8 +2854,10 @@ async fn serve_new_file(
 
             let (parts, body) = fwd_response.into_parts();
 
+            let counted = ClientCountedBody::new(body);
+
             let rated = MaybeRated::new(
-                body,
+                counted,
                 config.min_download_rate,
                 config.rate_check_timeframe,
                 RateCheckDirection::Client,
@@ -3872,7 +3920,7 @@ async fn pre_process_client_request(
             let (parts, body) = redirected_response.into_parts();
 
             metrics::REQUESTS_PASSTHROUGH.increment();
-            let counted = PassthroughBody { inner: body };
+            let counted = ClientCountedBody::new(PassthroughBody { inner: body });
 
             let rated = MaybeRated::new(
                 counted,
@@ -3902,7 +3950,7 @@ async fn pre_process_client_request(
     let (parts, body) = fwd_response.into_parts();
 
     metrics::REQUESTS_PASSTHROUGH.increment();
-    let counted = PassthroughBody { inner: body };
+    let counted = ClientCountedBody::new(PassthroughBody { inner: body });
 
     let rated = MaybeRated::new(
         counted,

--- a/src/splice_conn.rs
+++ b/src/splice_conn.rs
@@ -1760,7 +1760,12 @@ async fn splice_proxy_body(
     cache_path: &Path,
     total_content_length: u64,
 ) -> std::io::Result<(DownloadBarrier, Option<DemotedClientHandle>)> {
-    let _counter = client_counter::ClientDownload::new();
+    // Dropped at the demotion transition so the spawned `serve_remaining_from_file`
+    // task's own `ClientDownload` (in `async_sendfile_unfinished`) takes over the
+    // accounting cleanly — see the `ClientStatus::Demoted` branch below.
+    // `Option` is required because the borrow checker can't prove the demotion
+    // branch fires at most once per call when it's nested in the loop below.
+    let mut counter = Some(client_counter::ClientDownload::new());
 
     // Paired with BYTES_SERVED_SPLICE in tee_and_splice / boundary fallback.
     metrics::REQUESTS_SPLICE.increment();
@@ -1877,6 +1882,10 @@ async fn splice_proxy_body(
             .await?;
 
             if let ClientStatus::Demoted { client_bytes_sent } = client_status {
+                // Hand accounting off to the spawned demoted-serve task — its
+                // `async_sendfile_unfinished` creates its own `ClientDownload`
+                // so net `ACTIVE_CLIENT_DOWNLOADS` stays at 1 across the transition.
+                drop(counter.take());
                 demoted_handle = Some(spawn_file_serve_task(
                     client,
                     cache_path,
@@ -2073,7 +2082,12 @@ async fn splice_proxy_body_tls(
     cache_path: &Path,
     total_content_length: u64,
 ) -> std::io::Result<(DownloadBarrier, Option<DemotedClientHandle>)> {
-    let _counter = client_counter::ClientDownload::new();
+    // Dropped at the demotion transition so the spawned `serve_remaining_from_file`
+    // task's own `ClientDownload` (in `async_sendfile_unfinished`) takes over the
+    // accounting cleanly — see the `ClientStatus::Demoted` branch below.
+    // `Option` is required because the borrow checker can't prove the demotion
+    // branch fires at most once per call when it's nested in the loop below.
+    let mut counter = Some(client_counter::ClientDownload::new());
 
     // Paired with BYTES_SERVED_SPLICE in tee_and_splice / boundary fallback.
     metrics::REQUESTS_SPLICE.increment();
@@ -2198,6 +2212,10 @@ async fn splice_proxy_body_tls(
             .await?;
 
             if let ClientStatus::Demoted { client_bytes_sent } = client_status {
+                // Hand accounting off to the spawned demoted-serve task — its
+                // `async_sendfile_unfinished` creates its own `ClientDownload`
+                // so net `ACTIVE_CLIENT_DOWNLOADS` stays at 1 across the transition.
+                drop(counter.take());
                 demoted_handle = Some(spawn_file_serve_task(
                     client,
                     cache_path,


### PR DESCRIPTION
Three client-bound byte streams previously bypassed `ClientDownload`, under-counting `ACTIVE_CLIENT_DOWNLOADS` (and its peak):

- the hyper passthrough body for non-cacheable resources,
- upstream error-body relay in `serve_new_file`,
- and the parent `_counter` in `splice_proxy_body{,_tls}` which stayed alive while the spawned demoted file-serve task created its own, briefly double-counting one logical client.

Introduce `ClientCountedBody<B>` and wrap the two passthrough sites and the error-relay body. Switch the splice-proxy `_counter` to `Option<ClientDownload>` and drop it at the `ClientStatus::Demoted` transition so accounting hands off cleanly to `async_sendfile_unfinished`.