### PR TITLE
metrics: split HTTPS_UPGRADE_FAILED into REVERTED and terminal FAILED

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -332,7 +332,8 @@ pub(crate) async fn request_with_retry(
     // (gated on `attempt > MAX_ATTEMPTS` with `https_upgrade_test` still
     // set) relies on the Auto-mode revert firing first. If MAX_ATTEMPTS
     // were ever <= HTTPS_UPGRADE_REVERT_AFTER_ATTEMPTS, Auto mode would
-    // also fall through here with the flag set and over-count Auto.
+    // also fall through here with the flag set and bump HTTPS_UPGRADE_FAILED
+    // instead of HTTPS_UPGRADE_REVERTED.
     static_assert!(MAX_ATTEMPTS > HTTPS_UPGRADE_REVERT_AFTER_ATTEMPTS);
 
     debug_assert_eq!(
@@ -465,6 +466,14 @@ pub(crate) async fn request_with_retry(
                         metrics::HTTP_TIMEOUT_UPSTREAM_READ.increment();
                     }
                     metrics::UPSTREAM_HYPER_REQUEST_FAILED.increment();
+                    if https_upgrade_test {
+                        // Non-connect transport error (e.g. read timeout,
+                        // request framing) terminates the request without
+                        // retry. Count the upgrade attempt as failed so the
+                        // ATTEMPTED == SUCCEEDED + REVERTED + FAILED identity
+                        // holds.
+                        metrics::HTTPS_UPGRADE_FAILED.increment();
+                    }
                     warn_once_or_info!(
                         "Request of internal client to {} failed:  {}",
                         parts.uri,
@@ -498,7 +507,7 @@ pub(crate) async fn request_with_retry(
                                 .expect("authority must exist for a https upgrade")
                         );
 
-                        metrics::HTTPS_UPGRADE_FAILED.increment();
+                        metrics::HTTPS_UPGRADE_REVERTED.increment();
                         // reset https upgrade
                         let mut uri_parts = parts.uri.into_parts();
                         uri_parts.scheme.clone_from(&orig_scheme);
@@ -521,7 +530,8 @@ pub(crate) async fn request_with_retry(
                             // still set: in Always mode the revert branch
                             // above is gated off, so the only outcome of an
                             // attempted upgrade is failure here. Keep the
-                            // ATTEMPTED == SUCCEEDED + FAILED identity.
+                            // ATTEMPTED == SUCCEEDED + REVERTED + FAILED
+                            // identity.
                             metrics::HTTPS_UPGRADE_FAILED.increment();
                         }
                         if let Some(auth) = parts.uri.authority() {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -412,6 +412,9 @@ pub(crate) static LOGSTORE_EVICTIONS: Counter = Counter::new();
 pub(crate) static CACHE_QUOTA_UTIL_PEAK_BPS: Peak = Peak::new();
 
 /// HTTPS upgrade attempted on an HTTP request (Auto / uncached scheme).
+/// Every attempt resolves to exactly one of `HTTPS_UPGRADE_SUCCEEDED`,
+/// `HTTPS_UPGRADE_REVERTED`, or `HTTPS_UPGRADE_FAILED`, so the identity
+/// `ATTEMPTED == SUCCEEDED + REVERTED + FAILED` holds.
 pub(crate) static HTTPS_UPGRADE_ATTEMPTED: Counter = Counter::new();
 /// HTTPS upgrade succeeded: bumped on the first successful upstream
 /// response (any status) after the upgrade flag was set. The host's
@@ -420,9 +423,18 @@ pub(crate) static HTTPS_UPGRADE_ATTEMPTED: Counter = Counter::new();
 /// response with an unsupported scheme or a non-2xx status still
 /// counts as a success here.
 pub(crate) static HTTPS_UPGRADE_SUCCEEDED: Counter = Counter::new();
-/// HTTPS upgrade failed (Auto-mode revert to original scheme, or
-/// terminal connect failure with the upgrade flag still set in
-/// Always-mode).
+/// HTTPS upgrade reverted: Auto-mode gave up on the upgrade after
+/// `HTTPS_UPGRADE_REVERT_AFTER_ATTEMPTS` connect failures and reverted
+/// to the original scheme. The request itself may still succeed via the
+/// original scheme — this counter only marks that the upgrade attempt
+/// was abandoned, not that the request as a whole failed.
+pub(crate) static HTTPS_UPGRADE_REVERTED: Counter = Counter::new();
+/// HTTPS upgrade failed terminally: the request returned without
+/// the upgrade resolving to a success or a revert. Reached when
+/// Always-mode exhausts all `MAX_ATTEMPTS` connect retries (Auto-mode
+/// would have reverted first, see `HTTPS_UPGRADE_REVERTED`), or when
+/// any mode hits a non-connect transport error (e.g. read timeout,
+/// request framing) that terminates the request without retry.
 pub(crate) static HTTPS_UPGRADE_FAILED: Counter = Counter::new();
 
 /// Scheme-cache entries purged after `MAX_ATTEMPTS` connection failures.

--- a/src/web_interface.rs
+++ b/src/web_interface.rs
@@ -1797,13 +1797,14 @@ fn build_metrics_html() -> String {
     {
         let attempted = metrics::HTTPS_UPGRADE_ATTEMPTED.get();
         let succeeded = metrics::HTTPS_UPGRADE_SUCCEEDED.get();
+        let reverted = metrics::HTTPS_UPGRADE_REVERTED.get();
         let failed = metrics::HTTPS_UPGRADE_FAILED.get();
         t.row_tip(
-        "HTTPS Upgrade (attempted / succeeded / failed, scheme-cache removed)",
-        "HTTPS upgrade attempts on plain-HTTP requests, plus removals from the per-host scheme cache.",
+        "HTTPS Upgrade (attempted / succeeded / reverted / failed, scheme-cache removed)",
+        "HTTPS upgrade attempts on plain-HTTP requests (reverted: Auto-mode soft give-up; failed: Always-mode terminal failure), plus removals from the per-host scheme cache.",
         format_args!(
-            "{} / {succeeded} / {failed}, {}",
-            WarnIf::new(attempted, attempted != succeeded + failed),
+            "{} / {succeeded} / {reverted} / {failed}, {}",
+            WarnIf::new(attempted, attempted != succeeded + reverted + failed),
             metrics::SCHEME_CACHE_REMOVED.get(),
         ),
     );


### PR DESCRIPTION
Auto-mode revert (the request continues with the original scheme and may still succeed) and Always-mode terminal failure are operationally distinct outcomes — conflating them obscured Auto-mode tuning. Introduce HTTPS_UPGRADE_REVERTED for the former; reserve HTTPS_UPGRADE_FAILED for terminal failures. The new identity is ATTEMPTED == SUCCEEDED + REVERTED + FAILED, asserted in the web UI.