### PR TITLE
cache_metadata: skip fgetxattr per cache-hit conditional request

### DIFF
--- a/src/active_downloads.rs
+++ b/src/active_downloads.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use hashbrown::{Equivalent, HashMap, hash_map::Entry};
 
 use crate::ContentLength;
+use crate::cache_metadata::UpstreamMetadata;
 use crate::deb_mirror::Mirror;
 use crate::error::MirrorDownloadRate;
 use crate::{global_config, metrics};
@@ -50,8 +51,26 @@ pub(crate) enum AbortReason {
 #[derive(Debug)]
 pub(crate) enum ActiveDownloadStatus {
     Init(tokio::sync::watch::Receiver<()>),
-    Download(PathBuf, ContentLength, tokio::sync::watch::Receiver<()>),
-    Finished(PathBuf),
+    /// In-flight download; `meta` carries upstream-supplied `ETag` /
+    /// Last-Modified for late joiners that need them for response headers
+    /// or conditional-request decisions, avoiding xattr reads on the temp
+    /// file while it's still being written.
+    Download {
+        path: PathBuf,
+        content_length: ContentLength,
+        rx: tokio::sync::watch::Receiver<()>,
+        meta: Arc<UpstreamMetadata>,
+    },
+    /// Rename-completed (or revalidation-confirmed) cached file.
+    /// `meta` is `Some` when the values came from a fresh upstream
+    /// response (`RenameBarrier::release`); `None` when the entry was
+    /// produced by `InitBarrier::finished` (e.g. volatile-revalidation
+    /// 304) — in that case readers fall through to the post-flight
+    /// [`crate::cache_metadata`] cache, which lazy-loads from xattrs.
+    Finished {
+        path: PathBuf,
+        meta: Option<Arc<UpstreamMetadata>>,
+    },
     Aborted(AbortReason),
 }
 
@@ -331,8 +350,8 @@ impl ActiveDownloads {
 
             for entry in self.inner.read().values() {
                 let d = entry.status.blocking_read();
-                if let ActiveDownloadStatus::Download(_, size, _) = &*d {
-                    sum += size.upper().get();
+                if let ActiveDownloadStatus::Download { content_length, .. } = &*d {
+                    sum += content_length.upper().get();
                 }
             }
 
@@ -349,11 +368,11 @@ impl ActiveDownloads {
                 let d = entry.status.blocking_read();
                 match &*d {
                     ActiveDownloadStatus::Init(_)
-                    | ActiveDownloadStatus::Download(_, _, _)
+                    | ActiveDownloadStatus::Download { .. }
                     | ActiveDownloadStatus::Aborted(_) => {
                         count += 1;
                     }
-                    ActiveDownloadStatus::Finished(_) => (),
+                    ActiveDownloadStatus::Finished { .. } => (),
                 }
             }
 

--- a/src/cache_conditional.rs
+++ b/src/cache_conditional.rs
@@ -7,12 +7,13 @@
 //! `sendfile_conn.rs` previously rebuilt this view inline; sharing it keeps
 //! their behavior in lockstep.
 
+#[cfg(feature = "sendfile")]
 use std::path::Path;
 
-use crate::http_etag::if_none_match;
+use crate::cache_metadata::UpstreamMetadata;
 #[cfg(feature = "sendfile")]
-use crate::http_etag::read_etag;
-use crate::http_last_modified::read_last_modified;
+use crate::cache_metadata::{self, CacheMetadataKeyRef};
+use crate::http_etag::if_none_match;
 use crate::http_range::{HttpDate, cache_file_http_date, compute_age};
 
 /// Pre-computed cache representation metadata used to evaluate conditional
@@ -26,39 +27,38 @@ pub(crate) struct CacheInfo {
 }
 
 impl CacheInfo {
-    /// Build a [`CacheInfo`] reading both `ETag` and `Last-Modified` from the
-    /// file's xattrs.
+    /// Build a [`CacheInfo`] for a post-flight cache-hit serve, consulting
+    /// the in-process [`cache_metadata`] cache before any xattr read.
+    /// On miss, the cache lazy-loads from xattrs.
     #[cfg(feature = "sendfile")]
     #[must_use]
-    pub(crate) fn read(
+    pub(crate) fn resolve(
         file: &tokio::fs::File,
         file_path: &Path,
         metadata: &std::fs::Metadata,
+        key: &CacheMetadataKeyRef<'_>,
     ) -> Self {
-        Self::with_etag(file, file_path, metadata, read_etag(file, file_path))
+        let resolved = cache_metadata::store().resolve(key, file, file_path);
+        Self::with_meta(metadata, &resolved)
     }
 
-    /// Build a [`CacheInfo`] using a caller-supplied `file_etag` (e.g. one
-    /// already resolved through an `EtagState` cache to skip a redundant
-    /// xattr read).
+    /// Build a [`CacheInfo`] from a caller-supplied [`UpstreamMetadata`]
+    /// snapshot — typically the one carried on
+    /// [`crate::ActiveDownloadStatus::Download`] for late-joiner reads, so
+    /// no xattr/cache lookup happens at all.
     #[must_use]
-    pub(crate) fn with_etag(
-        file: &tokio::fs::File,
-        file_path: &Path,
-        metadata: &std::fs::Metadata,
-        file_etag: Option<String>,
-    ) -> Self {
+    pub(crate) fn with_meta(metadata: &std::fs::Metadata, meta: &UpstreamMetadata) -> Self {
         let cache_ts = cache_file_http_date(metadata);
 
-        let (last_modified_for_ims, last_modified_str) = match read_last_modified(file, file_path) {
-            Some((s, time)) => (time, s),
+        let (last_modified_for_ims, last_modified_str) = match meta.last_modified.as_ref() {
+            Some((s, time)) => (*time, s.clone()),
             None => (cache_ts, cache_ts.format()),
         };
 
         let age = compute_age(metadata);
 
         Self {
-            file_etag,
+            file_etag: meta.etag.clone(),
             last_modified_for_ims,
             last_modified_str,
             age,

--- a/src/cache_metadata.rs
+++ b/src/cache_metadata.rs
@@ -1,0 +1,484 @@
+//! Process-local cache for cached-file metadata (`ETag`, Last-Modified).
+//!
+//! See `dev/baselines/2026-05-08-e64d9328.summary.txt` for the profiling
+//! finding that motivated this: every cache-hit conditional-request path
+//! issues two `fgetxattr(2)` syscalls (one for the `ETag` xattr, one for
+//! Last-Modified), and the rustix bounds-check inside the xattr crate
+//! showed up at ~0.5 % of worker samples plus drove `block_in_place` and
+//! `spawn_blocking_inner` mutex traffic. Caching the parsed values per
+//! `(mirror, debname)` lets repeat hits skip the syscalls entirely.
+//!
+//! # Source-of-truth split
+//!
+//! - **In-flight downloads** carry their etag/last-modified directly on
+//!   [`crate::ActiveDownloadStatus::Download`] (and on `Finished` when
+//!   known). Late-joiner reads consult the status, never this cache.
+//! - **Post-flight (rename complete, active-downloads entry removed)** is
+//!   what this cache covers. The transition from in-flight to post-flight
+//!   happens inside `RenameBarrier::release`, which calls
+//!   [`CacheMetadataStore::set`] (via `cache_metadata::store().set(...)`)
+//!   *before* removing the active-downloads entry — so a worker that
+//!   misses the entry always finds the cache populated.
+//!
+//! The xattrs on the cached file remain the persistent source of truth.
+//! This cache is empty at boot; the first read for each file falls back
+//! to the xattr helpers and inserts the result. xattr writes still happen
+//! on the download path (see `xattr_helpers::write_*`) so the values
+//! survive process restarts.
+//!
+//! # Publication invariant
+//!
+//! `resolve`'s cold path releases the read lock before reading xattrs and
+//! re-acquires the write lock to insert.  A concurrent
+//! [`CacheMetadataStore::set`] can win that race and publish a fresher
+//! value before resolve's insert runs.  To keep resolve from clobbering
+//! the published value, every caller of [`CacheMetadataStore::set`]
+//! **must** persist matching xattrs to the cached file *before* invoking
+//! `set`.  With that invariant, the value
+//! the racing `resolve` reads from xattrs equals the value `set`
+//! published, so the two writers race to insert equivalent `Arc`s.
+//!
+//! Resolve's insert re-checks the entry under the write lock: if `set`
+//! got there first, it returns the published `Arc` and `debug_assert!`s
+//! it matches what we just read from xattrs.  If the assertion ever
+//! fires, a caller of `set` published metadata without first writing
+//! matching xattrs — fix that caller, not the assertion.
+//!
+//! The assertion is skipped when the xattr read produced `(None, None)`:
+//! `xattr_helpers::write_helper` is best-effort and silently swallows
+//! `ErrorKind::Unsupported`, so on filesystems without xattr support a
+//! caller's xattr write is a no-op and the racing `resolve` legitimately
+//! reads `(None, None)` while `set` publishes `Some(...)`.  The publisher's
+//! value still wins; we just don't crash debug builds in that environment.
+//!
+//! # Negative caching and transient errors
+//!
+//! Successfully observing absent xattrs (no value, FS doesn't support
+//! xattrs, or a malformed value was scrubbed) inserts a `(None, None)`
+//! entry — subsequent hits skip the syscalls.  Transient I/O failures
+//! (e.g. `EIO`) are deliberately NOT cached: a one-time syscall failure
+//! would otherwise pin the negative entry until process restart and
+//! silently disable conditional-request handling.  When *either* xattr
+//! read errors, `resolve` returns a best-effort `Arc` for the current
+//! request that contains whichever fields succeeded (so an `EIO` on the
+//! `ETag` xattr while Last-Modified read cleanly yields
+//! `(None, Some(...))`, and vice versa) but does not insert; the next
+//! reader retries both syscalls.
+
+use std::{hash::Hash, path::Path, sync::Arc};
+
+use hashbrown::{Equivalent, HashMap, hash_map::Entry};
+
+use crate::{
+    deb_mirror::Mirror, http_etag::try_read_etag, http_last_modified::try_read_last_modified,
+    http_range::HttpDate,
+};
+
+/// Upstream-supplied metadata for a single cached file.  Used both as the
+/// in-flight value carried on [`crate::ActiveDownloadStatus::Download`] and
+/// as the post-flight cache entry.
+///
+/// `last_modified` stores both the raw header string (for `Last-Modified`
+/// response headers) and its parsed [`HttpDate`] (for If-Modified-Since
+/// comparison) so consumers don't re-parse on every hit.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct UpstreamMetadata {
+    pub(crate) etag: Option<String>,
+    pub(crate) last_modified: Option<(String, HttpDate)>,
+}
+
+impl UpstreamMetadata {
+    /// Build from raw upstream header strings.  The Last-Modified pair is
+    /// produced only if the value parses as a valid HTTP-date.
+    #[must_use]
+    pub(crate) fn from_upstream(etag: Option<String>, last_modified: Option<String>) -> Self {
+        let last_modified = last_modified.and_then(|s| HttpDate::parse(&s).map(|t| (s, t)));
+        Self {
+            etag,
+            last_modified,
+        }
+    }
+}
+
+/// A wrapper around [`UpstreamMetadata`] that supports borrowed, owned, and
+/// shared references.
+pub(crate) enum UpstreamMetadataView<'a> {
+    Borrowed(&'a UpstreamMetadata),
+    Arc(Arc<UpstreamMetadata>),
+}
+
+impl std::ops::Deref for UpstreamMetadataView<'_> {
+    type Target = UpstreamMetadata;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Borrowed(meta) => meta,
+            Self::Arc(meta) => meta,
+        }
+    }
+}
+
+/// Cache key.  Mirrors the keying used by `active_downloads.rs` so the
+/// in-flight and post-flight stores look up the same logical resource.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct CacheMetadataKey {
+    pub(crate) mirror: Mirror,
+    pub(crate) debname: String,
+}
+
+impl CacheMetadataKey {
+    #[must_use]
+    pub(crate) fn new(mirror: Mirror, debname: String) -> Self {
+        Self { mirror, debname }
+    }
+}
+
+/// Borrow-only counterpart to [`CacheMetadataKey`].  Used as a lookup key
+/// on the hot-path `resolve` to avoid cloning `Mirror` and `debname` on
+/// every cache hit; mirrors the `ActiveDownloadKeyRef` pattern in
+/// `active_downloads.rs`.
+#[derive(Hash)]
+pub(crate) struct CacheMetadataKeyRef<'a> {
+    pub(crate) mirror: &'a Mirror,
+    pub(crate) debname: &'a str,
+}
+
+impl<'a> CacheMetadataKeyRef<'a> {
+    #[must_use]
+    pub(crate) fn new(mirror: &'a Mirror, debname: &'a str) -> Self {
+        Self { mirror, debname }
+    }
+
+    /// Materialise an owned [`CacheMetadataKey`] (used on the cold-path
+    /// insert when a resolve misses).
+    #[must_use]
+    fn to_owned(&self) -> CacheMetadataKey {
+        CacheMetadataKey {
+            mirror: self.mirror.clone(),
+            debname: self.debname.to_owned(),
+        }
+    }
+}
+
+impl Equivalent<CacheMetadataKey> for CacheMetadataKeyRef<'_> {
+    fn equivalent(&self, key: &CacheMetadataKey) -> bool {
+        self.mirror == &key.mirror && self.debname == key.debname
+    }
+}
+
+/// Process-local cache mapping `(mirror, debname)` to the most recently
+/// observed upstream metadata for the file.  Lookups return an [`Arc`] so
+/// readers drop the map lock before inspecting fields.
+pub(crate) struct CacheMetadataStore {
+    map: parking_lot::RwLock<HashMap<CacheMetadataKey, Arc<UpstreamMetadata>>>,
+}
+
+impl std::fmt::Debug for CacheMetadataStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Avoid dumping the entire map (could be large and mostly noise)
+        // and avoid acquiring the lock so this is safe to call from any
+        // context — e.g. `Result::expect(...)` at startup.
+        f.debug_struct("CacheMetadataStore").finish_non_exhaustive()
+    }
+}
+
+impl CacheMetadataStore {
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self {
+            map: parking_lot::RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Look up the cached metadata for a key; on miss, read xattrs from
+    /// the supplied file and populate the entry.  The caller must already
+    /// have an open `tokio::fs::File` for the cached path so the xattr
+    /// lookups address the same inode the caller is serving from.
+    ///
+    /// The hot-path lookup is zero-clone — readers pass a
+    /// [`CacheMetadataKeyRef`] that borrows the caller's `Mirror` and
+    /// `debname`, and we only materialise an owned [`CacheMetadataKey`]
+    /// on the cold cache-miss insert.  The `block_in_place` round-trip
+    /// happens only on miss; subsequent hits return an [`Arc`] clone with
+    /// no syscalls.
+    pub(crate) fn resolve<K>(
+        &self,
+        key: &K,
+        file: &tokio::fs::File,
+        path: &Path,
+    ) -> Arc<UpstreamMetadata>
+    where
+        K: Hash + Equivalent<CacheMetadataKey> + ?Sized,
+        Self: ResolveOwn<K>,
+    {
+        if let Some(entry) = self.map.read().get(key) {
+            return Arc::clone(entry);
+        }
+
+        // Cold path: fetch from xattrs.  If either read errors, surface
+        // a best-effort `Arc` containing whichever fields succeeded for
+        // this request but do not insert — see the "Negative caching
+        // and transient errors" section in the module docs.
+        let etag_res = try_read_etag(file, path);
+        let last_modified_res = try_read_last_modified(file, path);
+        let (etag, last_modified) = match (etag_res, last_modified_res) {
+            (Ok(etag), Ok(last_modified)) => (etag, last_modified),
+            (etag_res, last_modified_res) => {
+                return Arc::new(UpstreamMetadata {
+                    etag: etag_res.ok().flatten(),
+                    last_modified: last_modified_res.ok().flatten(),
+                });
+            }
+        };
+
+        let meta = Arc::new(UpstreamMetadata {
+            etag,
+            last_modified,
+        });
+
+        // Re-check under the write lock: a concurrent `set` may have
+        // published a value while we were reading xattrs.  Per the
+        // publication invariant (see module docs), that value must
+        // equal what we just read; the debug_assert catches violations.
+        // In release we trust the publisher's value.
+        //
+        // Exception: if our xattr read produced `(None, None)`, treat it
+        // as "xattrs unavailable on this FS" (the `write_helper` is best-
+        // effort and silently swallows `ErrorKind::Unsupported`), trust
+        // the publisher, and skip the assert.  Asserting here would fire
+        // spuriously on filesystems without xattr support.
+        let owned = <Self as ResolveOwn<K>>::own(key);
+        let mut map = self.map.write();
+        match map.entry(owned) {
+            Entry::Occupied(occ) => {
+                debug_assert!(
+                    (meta.etag.is_none() && meta.last_modified.is_none())
+                        || occ.get().as_ref() == meta.as_ref(),
+                    "publication invariant violated: a concurrent `set` published \
+                     metadata that disagrees with the on-disk xattrs; every caller \
+                     of `set` must persist matching xattrs first (published={:?}, \
+                     read={:?})",
+                    occ.get().as_ref(),
+                    meta.as_ref(),
+                );
+                Arc::clone(occ.get())
+            }
+            Entry::Vacant(vac) => {
+                vac.insert(Arc::clone(&meta));
+                meta
+            }
+        }
+    }
+
+    /// Replace the entry for `key` with `meta`.  Used by the rename
+    /// barrier transition to publish post-flight metadata before clearing
+    /// the active-downloads entry.  The volatile-revalidation 304 path
+    /// does **not** call this — the cached file's xattrs are unchanged
+    /// across the revalidation, so a subsequent [`Self::resolve`] lazy-
+    /// loads the same values directly from xattr.
+    ///
+    /// **Publication invariant:** callers must have already persisted
+    /// matching xattrs to the cached file before invoking this.  See
+    /// the module-level docs for the rationale (a concurrent cold-path
+    /// [`Self::resolve`] reads xattrs after releasing its read lock and
+    /// would otherwise clobber the published value with the stale xattr
+    /// read).
+    pub(crate) fn set(&self, key: CacheMetadataKey, meta: Arc<UpstreamMetadata>) {
+        self.map.write().insert(key, meta);
+    }
+
+    /// Drop any cached entry for `key`.  Called from cleanup file
+    /// removal and (in principle) from any other context where the on-
+    /// disk file is going away.  Accepts borrowed keys via the same
+    /// [`Equivalent`] mechanism as `resolve`, so callers don't need to
+    /// clone `Mirror` and `debname` to invalidate.
+    pub(crate) fn invalidate<K>(&self, key: &K)
+    where
+        K: Hash + Equivalent<CacheMetadataKey> + ?Sized,
+    {
+        self.map.write().remove(key);
+    }
+
+    /// Number of currently cached entries.  Used by tests and by the web
+    /// interface "Daemon Status" row that surfaces in-memory cache size.
+    pub(crate) fn len(&self) -> usize {
+        self.map.read().len()
+    }
+}
+
+/// Helper trait used by [`CacheMetadataStore::resolve`] to materialise an
+/// owned [`CacheMetadataKey`] on the cold cache-miss insert.  Implemented
+/// for both the borrowed [`CacheMetadataKeyRef`] (hot-path callers) and
+/// the owned [`CacheMetadataKey`] (test/cold callers).
+pub(crate) trait ResolveOwn<K: ?Sized> {
+    fn own(key: &K) -> CacheMetadataKey;
+}
+
+impl ResolveOwn<CacheMetadataKey> for CacheMetadataStore {
+    #[inline]
+    fn own(key: &CacheMetadataKey) -> CacheMetadataKey {
+        key.clone()
+    }
+}
+
+impl ResolveOwn<CacheMetadataKeyRef<'_>> for CacheMetadataStore {
+    #[inline]
+    fn own(key: &CacheMetadataKeyRef<'_>) -> CacheMetadataKey {
+        key.to_owned()
+    }
+}
+
+mod store {
+    //! Global handle to the singleton [`CacheMetadataStore`].  The pattern
+    //! mirrors `database_task::DB_TASK_QUEUE_SENDER`: initialised once at
+    //! startup, accessed via a typed getter that panics if uninitialised
+    //! (which would be a logic bug — startup is required to call `init`).
+
+    use std::sync::OnceLock;
+
+    use super::CacheMetadataStore;
+
+    static STORE: OnceLock<CacheMetadataStore> = OnceLock::new();
+
+    /// Install the singleton store.  Returns `Err` (with the rejected
+    /// new instance) if `init` was already called; mirrors
+    /// `OnceLock::set` so callers can `.expect("...")` at startup like
+    /// `database_task::DB_TASK_QUEUE_SENDER` does.
+    pub(crate) fn init() -> Result<(), CacheMetadataStore> {
+        STORE.set(CacheMetadataStore::new())
+    }
+
+    #[must_use]
+    pub(crate) fn store() -> &'static CacheMetadataStore {
+        STORE.get().expect(
+            "cache_metadata::store called before init; main() must invoke cache_metadata::init",
+        )
+    }
+}
+
+pub(crate) use store::{init, store};
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use tokio::fs::File;
+
+    use super::*;
+    use crate::deb_mirror::Mirror;
+    use crate::http_etag::write_etag;
+    use crate::http_last_modified::write_last_modified;
+
+    fn fixture_key() -> CacheMetadataKey {
+        CacheMetadataKey::new(
+            Mirror::new(
+                String::from("example.test").into(),
+                std::num::NonZero::new(80),
+                "/debian".into(),
+            ),
+            "test.deb".into(),
+        )
+    }
+
+    async fn fixture_file() -> (tempfile::TempDir, File, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("probe.deb");
+        let file = File::create(&path).await.expect("create file");
+        (dir, file, path)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn resolve_misses_then_caches() {
+        let store = CacheMetadataStore::new();
+        let (_dir, file, path) = fixture_file().await;
+        write_etag(&file, &path, "\"abc\"");
+        write_last_modified(&file, &path, "Thu, 01 Jan 1970 00:00:00 GMT");
+
+        let key = fixture_key();
+        let first = store.resolve(&key, &file, &path);
+        assert_eq!(first.etag.as_deref(), Some("\"abc\""));
+        assert!(first.last_modified.is_some());
+        assert_eq!(store.len(), 1);
+
+        // Mutate the file's xattr to confirm the second resolve returns the
+        // cached value, not a fresh disk read.  We also skip the assertion
+        // entirely on filesystems that reject xattr writes (the prior
+        // `write_etag` would have silently been a no-op).
+        if first.etag.is_none() && first.last_modified.is_none() {
+            return;
+        }
+        write_etag(&file, &path, "\"xyz\"");
+        let second = store.resolve(&key, &file, &path);
+        assert_eq!(second.etag.as_deref(), Some("\"abc\""));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn set_overwrites_existing_entry() {
+        let store = CacheMetadataStore::new();
+        let key = fixture_key();
+        store.set(
+            key.clone(),
+            Arc::new(UpstreamMetadata::from_upstream(
+                Some("\"old\"".into()),
+                None,
+            )),
+        );
+        store.set(
+            key.clone(),
+            Arc::new(UpstreamMetadata::from_upstream(
+                Some("\"new\"".into()),
+                None,
+            )),
+        );
+        let (_dir, file, path) = fixture_file().await;
+        let entry = store.resolve(&key, &file, &path);
+        assert_eq!(entry.etag.as_deref(), Some("\"new\""));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn invalidate_drops_entry() {
+        let store = CacheMetadataStore::new();
+        let key = fixture_key();
+        store.set(
+            key.clone(),
+            Arc::new(UpstreamMetadata::from_upstream(
+                Some("\"abc\"".into()),
+                None,
+            )),
+        );
+        assert_eq!(store.len(), 1);
+        store.invalidate(&key);
+        assert_eq!(store.len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn negative_caching_for_absent_xattrs() {
+        let store = CacheMetadataStore::new();
+        let (_dir, file, path) = fixture_file().await;
+        let key = fixture_key();
+        let entry = store.resolve(&key, &file, &path);
+        assert!(entry.etag.is_none());
+        assert!(entry.last_modified.is_none());
+        // Second call still hits the cache.
+        assert_eq!(store.len(), 1);
+        let _again = store.resolve(&key, &file, &path);
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn from_upstream_parses_last_modified() {
+        let m = UpstreamMetadata::from_upstream(
+            Some("\"abc\"".into()),
+            Some("Thu, 01 Jan 1970 00:00:00 GMT".into()),
+        );
+        assert_eq!(m.etag.as_deref(), Some("\"abc\""));
+        let (s, _date) = m.last_modified.expect("parsed");
+        assert_eq!(s, "Thu, 01 Jan 1970 00:00:00 GMT");
+    }
+
+    #[test]
+    fn from_upstream_drops_malformed_last_modified() {
+        let m = UpstreamMetadata::from_upstream(None, Some("not a date".into()));
+        assert!(m.last_modified.is_none());
+    }
+}

--- a/src/guards.rs
+++ b/src/guards.rs
@@ -2,7 +2,10 @@ use std::{path::PathBuf, sync::Arc};
 
 use crate::{
     AbortReason, ActiveDownloadStatus, ActiveDownloads, ContentLength,
-    cache_quota::QuotaReservation, deb_mirror::Mirror, metrics,
+    cache_metadata::{self, CacheMetadataKey, UpstreamMetadata},
+    cache_quota::QuotaReservation,
+    deb_mirror::Mirror,
+    metrics,
 };
 #[cfg(feature = "splice")]
 use crate::{
@@ -43,10 +46,15 @@ impl<'a> InitBarrier<'a> {
         }
     }
 
+    /// Finalise the entry without going through `Download` (e.g. a
+    /// volatile-revalidation 304 from upstream — the existing on-disk
+    /// file remains valid).  No upstream metadata is published; readers
+    /// that observe `Finished { meta: None }` fall through to the
+    /// post-flight cache, which will lazy-load from xattr if needed.
     pub(crate) async fn finished(mut self, path: PathBuf) {
         let data = self.data.take().expect("every sink consumes the instance");
 
-        *data.status.write().await = ActiveDownloadStatus::Finished(path);
+        *data.status.write().await = ActiveDownloadStatus::Finished { path, meta: None };
         data.active_downloads.remove(data.mirror, data.debname);
     }
 
@@ -55,12 +63,18 @@ impl<'a> InitBarrier<'a> {
         path: PathBuf,
         content_length: ContentLength,
         quota_reservation: Option<QuotaReservation>,
+        meta: Arc<UpstreamMetadata>,
     ) -> DownloadBarrier {
         let data = self.data.take().expect("every sink consumes the instance");
 
         let (tx, rx) = tokio::sync::watch::channel(());
 
-        *data.status.write().await = ActiveDownloadStatus::Download(path, content_length, rx);
+        *data.status.write().await = ActiveDownloadStatus::Download {
+            path,
+            content_length,
+            rx,
+            meta,
+        };
 
         DownloadBarrier {
             data: Some(DownloadBarrierData {
@@ -279,6 +293,16 @@ pub(crate) struct RenameBarrier {
 }
 
 impl RenameBarrier {
+    /// Transition the barrier to `Finished`, publish the upstream metadata
+    /// to the post-flight [`cache_metadata`] cache, and clear the
+    /// active-downloads entry.
+    ///
+    /// Ordering matters: the cache is populated **before** the entry is
+    /// removed so that workers which miss the active-downloads entry
+    /// always find the cache primed with the rename's values.  Conversely,
+    /// workers that still see the entry observe `Finished { meta = Some
+    /// (...) }` and read the values directly from status.  Either way they
+    /// agree with the on-disk file produced by the just-completed rename.
     pub(crate) fn release(mut self, path: PathBuf, bytes_received: u64) {
         let mut data = self.data.take().expect("every sink consumes the instance");
 
@@ -286,9 +310,38 @@ impl RenameBarrier {
             reservation.finalize(bytes_received);
         }
 
-        *data.lock = ActiveDownloadStatus::Finished(path);
+        // Carry the in-flight metadata over to the post-flight cache and
+        // the `Finished` status before we tear the active-downloads entry
+        // down.  The barrier reached this point via `DownloadBarrier`
+        // (which set the status to `Download { meta }`); any other shape
+        // is a logic bug — log it, fall back to no metadata, and proceed
+        // with the status / cache transitions so the active-downloads
+        // entry doesn't leak.
+        let meta_for_status: Option<Arc<UpstreamMetadata>> = match &*data.lock {
+            ActiveDownloadStatus::Download { meta, .. } => Some(Arc::clone(meta)),
+            ActiveDownloadStatus::Init(_)
+            | ActiveDownloadStatus::Finished { .. }
+            | ActiveDownloadStatus::Aborted(_) => {
+                log::error!(
+                    "RenameBarrier::release reached with non-Download status: {:?}",
+                    *data.lock
+                );
+                None
+            }
+        };
+
+        *data.lock = ActiveDownloadStatus::Finished {
+            path,
+            meta: meta_for_status.clone(),
+        };
         drop(data.lock);
 
+        if let Some(meta) = meta_for_status {
+            cache_metadata::store().set(
+                CacheMetadataKey::new(data.mirror.clone(), data.debname.clone()),
+                meta,
+            );
+        }
         data.active_downloads.remove(&data.mirror, &data.debname);
     }
 }

--- a/src/http_etag.rs
+++ b/src/http_etag.rs
@@ -33,12 +33,18 @@ pub(crate) fn is_valid_etag(s: &str) -> bool {
             .all(|&c| c == 0x21 || (0x23..=0x7E).contains(&c) || c >= 0x80)
 }
 
-/// Read an `ETag` from the file's extended attributes.
+/// Read an `ETag` from the file's extended attributes, distinguishing
+/// transient I/O errors from a stable "no value" outcome.
 ///
-/// Returns `None` on any error (graceful degradation).
-#[must_use]
-pub(crate) fn read_etag(file: &tokio::fs::File, display_path: &Path) -> Option<String> {
-    let data = xattr_helpers::read_helper(file, display_path, XATTR_ETAG)?;
+/// See [`xattr_helpers::try_read_helper`] for the semantics; a malformed
+/// stored `ETag` is scrubbed and reported as `Ok(None)`.
+pub(crate) fn try_read_etag(
+    file: &tokio::fs::File,
+    display_path: &Path,
+) -> Result<Option<String>, xattr_helpers::XattrIoError> {
+    let Some(data) = xattr_helpers::try_read_helper(file, display_path, XATTR_ETAG)? else {
+        return Ok(None);
+    };
 
     if !is_valid_etag(&data) {
         warn!(
@@ -49,10 +55,20 @@ pub(crate) fn read_etag(file: &tokio::fs::File, display_path: &Path) -> Option<S
 
         xattr_helpers::remove_helper(file, display_path, XATTR_ETAG);
 
-        return None;
+        return Ok(None);
     }
 
-    Some(data)
+    Ok(Some(data))
+}
+
+/// Read an `ETag` from the file's extended attributes.
+///
+/// Returns `None` on any error (graceful degradation).  Callers that
+/// need to distinguish transient I/O errors from a stable "no value"
+/// outcome should use [`try_read_etag`].
+#[must_use]
+pub(crate) fn read_etag(file: &tokio::fs::File, display_path: &Path) -> Option<String> {
+    try_read_etag(file, display_path).ok().flatten()
 }
 
 /// Write an `ETag` to the file's extended attributes.

--- a/src/http_last_modified.rs
+++ b/src/http_last_modified.rs
@@ -13,16 +13,20 @@ fn is_valid_http_date(s: &str) -> bool {
     HttpDate::parse(s).is_some()
 }
 
-/// Read a `Last-Modified` value from the file's extended attributes.
+/// Read a `Last-Modified` value from the file's extended attributes,
+/// distinguishing transient I/O errors from a stable "no value" outcome.
 ///
-/// Returns `None` on any error or if the stored value is not a valid HTTP-date
-/// (graceful degradation).
-#[must_use]
-pub(crate) fn read_last_modified(
+/// See [`xattr_helpers::try_read_helper`] for the semantics; a stored
+/// value that fails to parse as an HTTP-date is scrubbed and reported
+/// as `Ok(None)`.
+pub(crate) fn try_read_last_modified(
     file: &tokio::fs::File,
     display_path: &Path,
-) -> Option<(String, HttpDate)> {
-    let data = xattr_helpers::read_helper(file, display_path, XATTR_LAST_MODIFIED)?;
+) -> Result<Option<(String, HttpDate)>, xattr_helpers::XattrIoError> {
+    let Some(data) = xattr_helpers::try_read_helper(file, display_path, XATTR_LAST_MODIFIED)?
+    else {
+        return Ok(None);
+    };
 
     let Some(time) = HttpDate::parse(&data) else {
         warn!(
@@ -33,10 +37,10 @@ pub(crate) fn read_last_modified(
 
         xattr_helpers::remove_helper(file, display_path, XATTR_LAST_MODIFIED);
 
-        return None;
+        return Ok(None);
     };
 
-    Some((data, time))
+    Ok(Some((data, time)))
 }
 
 /// Write a `Last-Modified` value to the file's extended attributes.
@@ -79,7 +83,7 @@ mod tests {
         write_last_modified(&file, &path, value);
 
         // Skip the round-trip assertion when xattrs aren't supported on the test FS.
-        if let Some((got_str, got_time)) = read_last_modified(&file, &path) {
+        if let Ok(Some((got_str, got_time))) = try_read_last_modified(&file, &path) {
             assert_eq!(got_str, value);
             assert_eq!(got_time, HttpDate::from_secs(12_345_678_909));
         }
@@ -92,6 +96,6 @@ mod tests {
         let file = tokio::fs::File::create(&path).await.expect("create file");
 
         write_last_modified(&file, &path, "garbage");
-        assert_eq!(read_last_modified(&file, &path), None);
+        assert!(matches!(try_read_last_modified(&file, &path), Ok(None)));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 mod active_downloads;
 mod cache_conditional;
+mod cache_metadata;
 mod cache_quota;
 mod channel_body;
 mod config;
@@ -144,6 +145,8 @@ use tokio::signal::unix::SignalKind;
 use crate::active_downloads::OriginateOutcome;
 use crate::active_downloads::{AbortReason, ActiveDownloadStatus, ActiveDownloads, InsertOutcome};
 use crate::cache_conditional::CacheInfo;
+use crate::cache_metadata::UpstreamMetadata;
+use crate::cache_metadata::UpstreamMetadataView;
 use crate::cache_quota::QuotaExceeded;
 use crate::config::Config;
 use crate::config::DomainName;
@@ -1141,36 +1144,21 @@ impl Body for MmapBody {
     }
 }
 
-enum EtagState {
-    Some(String),
-    Failure,
-    Unknown,
-}
-
-impl EtagState {
-    fn from_option(etag: Option<String>) -> Self {
-        match etag {
-            Some(etag) => Self::Some(etag),
-            None => Self::Failure,
-        }
-    }
-}
-
 #[must_use]
 async fn serve_cached_file(
     conn_details: ConnectionDetails,
     req: &Request<Empty<()>>,
     file: tokio::fs::File,
     file_path: PathBuf,
-    file_etag: EtagState,
-    prefetched_metadata: Option<std::fs::Metadata>,
+    prefetched_upstream_metadata: Option<&UpstreamMetadata>,
+    prefetched_local_metadata: Option<std::fs::Metadata>,
 ) -> Response<ProxyCacheBody> {
     let aliased = match conn_details.aliased_host {
         Some(alias) => format!(" aliased to host {alias}"),
         None => String::new(),
     };
 
-    let metadata = match prefetched_metadata {
+    let metadata = match prefetched_local_metadata {
         Some(m) => m,
         None => match file.metadata().await {
             Ok(m) => m,
@@ -1187,11 +1175,16 @@ async fn serve_cached_file(
 
     let file_size = metadata.len();
 
-    // Use the provided ETag or fall back to reading from the file if not provided
-    let resolved_etag = match file_etag {
-        EtagState::Some(etag) => Some(etag),
-        EtagState::Failure => None,
-        EtagState::Unknown => read_etag(&file, &file_path),
+    let cache_key =
+        cache_metadata::CacheMetadataKeyRef::new(&conn_details.mirror, &conn_details.debname);
+
+    // Caller pre-resolves on the volatile / late-joiner / originator paths;
+    // otherwise fall back to the post-flight cache (lazy-loads xattr on miss).
+    let resolved_meta = match prefetched_upstream_metadata {
+        Some(meta) => UpstreamMetadataView::Borrowed(meta),
+        None => UpstreamMetadataView::Arc(
+            cache_metadata::store().resolve(&cache_key, &file, &file_path),
+        ),
     };
 
     let if_none_match_str = match req.headers().get(IF_NONE_MATCH) {
@@ -1213,7 +1206,7 @@ async fn serve_cached_file(
         .get(IF_MODIFIED_SINCE)
         .and_then(|v| v.to_str().ok());
 
-    let cache_info = CacheInfo::with_etag(&file, &file_path, &metadata, resolved_etag);
+    let cache_info = CacheInfo::with_meta(&metadata, &resolved_meta);
     let serve_304 = cache_info.decide_serve_304(if_none_match_str, if_modified_since_str);
 
     let cache_conditional::CacheInfo {
@@ -1670,15 +1663,8 @@ async fn serve_volatile_file(
             #[cfg(not(feature = "sendfile"))]
             metrics::VOLATILE_HIT.increment();
 
-            return serve_cached_file(
-                conn_details,
-                &req,
-                file,
-                file_path,
-                EtagState::Unknown,
-                Some(metadata),
-            )
-            .await;
+            return serve_cached_file(conn_details, &req, file, file_path, None, Some(metadata))
+                .await;
         }
     } else {
         warn!(
@@ -1702,7 +1688,7 @@ async fn serve_volatile_file(
                 "Serving file {} already in cache / download from mirror {} for client {}...",
                 conn_details.debname, conn_details.mirror, conn_details.client
             );
-            serve_downloading_file(conn_details, req, status, EtagState::Unknown).await
+            serve_downloading_file(conn_details, req, status, None).await
         }
         InsertOutcome::Originator { init_tx, status } => {
             serve_new_file(
@@ -2014,16 +2000,9 @@ async fn serve_unfinished_file(
     status: Arc<tokio::sync::RwLock<ActiveDownloadStatus>>,
     content_length: ContentLength,
     mut receiver: tokio::sync::watch::Receiver<()>,
-    upstream_etag: EtagState,
+    upstream_metadata: &UpstreamMetadata,
 ) -> Response<ProxyCacheBody> {
     let config = global_config();
-
-    // For joining clients, try reading from xattr as the download task may have already written it.
-    let resolved_etag = match upstream_etag {
-        EtagState::Some(etag) => Some(etag),
-        EtagState::Failure => None,
-        EtagState::Unknown => read_etag(&file, &file_path),
-    };
 
     let md = match file.metadata().await {
         Ok(data) => data,
@@ -2042,7 +2021,7 @@ async fn serve_unfinished_file(
         last_modified_str,
         age,
         last_modified_for_ims: _,
-    } = CacheInfo::with_etag(&file, &file_path, &md, resolved_etag);
+    } = CacheInfo::with_meta(&md, upstream_metadata);
 
     let content_type = content_type_for_cached_file(&conn_details.debname);
     let (tx, rx) = tokio::sync::mpsc::channel(64);
@@ -2099,7 +2078,7 @@ async fn serve_unfinished_file(
                 /* sender closed, either download finished or aborted */
                 let st = status.read().await;
                 let _: Never = match *st {
-                    ActiveDownloadStatus::Finished(_) => {
+                    ActiveDownloadStatus::Finished { .. } => {
                         drop(st);
                         finished = true;
                         continue;
@@ -2123,7 +2102,7 @@ async fn serve_unfinished_file(
 
                         return;
                     }
-                    ActiveDownloadStatus::Init(_) | ActiveDownloadStatus::Download(..) => {
+                    ActiveDownloadStatus::Init(_) | ActiveDownloadStatus::Download { .. } => {
                         error!(
                             "Invalid download state {:?} of file `{}`, cancelling stream",
                             *st,
@@ -2220,7 +2199,7 @@ async fn serve_downloading_file(
     conn_details: ConnectionDetails,
     req: Request<Empty<()>>,
     status: Arc<tokio::sync::RwLock<ActiveDownloadStatus>>,
-    upstream_etag: EtagState,
+    prefetched_upstream_metadata: Option<&UpstreamMetadata>,
 ) -> Response<ProxyCacheBody> {
     let mut init_waited = false;
 
@@ -2255,8 +2234,15 @@ async fn serve_downloading_file(
                 let _ignore = init_rx.changed().await;
                 init_waited = true;
             }
-            ActiveDownloadStatus::Finished(path) => {
+            ActiveDownloadStatus::Finished { path, meta, .. } => {
                 let path_clone = path.clone();
+                let prefetched_upstream_metadata = if let Some(meta) = prefetched_upstream_metadata
+                {
+                    Some(UpstreamMetadataView::Borrowed(meta))
+                } else {
+                    meta.as_ref()
+                        .map(|meta| UpstreamMetadataView::Arc(Arc::clone(meta)))
+                };
                 drop(st);
                 drop(status);
                 let file = match tokio::fs::File::open(&path_clone).await {
@@ -2279,12 +2265,17 @@ async fn serve_downloading_file(
                     &req,
                     file,
                     path_clone,
-                    upstream_etag,
+                    prefetched_upstream_metadata.as_deref(),
                     None,
                 )
                 .await;
             }
-            ActiveDownloadStatus::Download(path, content_length, receiver) => {
+            ActiveDownloadStatus::Download {
+                path,
+                content_length,
+                rx: receiver,
+                meta,
+            } => {
                 // Cannot use mmap(2) since the file is not yet completely written
                 let file = match tokio::fs::File::open(&path).await {
                     Ok(f) => f,
@@ -2303,6 +2294,7 @@ async fn serve_downloading_file(
                 let path_clone = path.clone();
                 let content_length_copy = *content_length;
                 let receiver_clone = receiver.clone();
+                let upstream_metadata = Arc::clone(meta);
                 drop(st);
 
                 return serve_unfinished_file(
@@ -2312,7 +2304,7 @@ async fn serve_downloading_file(
                     status,
                     content_length_copy,
                     receiver_clone,
-                    upstream_etag,
+                    &upstream_metadata,
                 )
                 .await;
             }
@@ -2507,7 +2499,7 @@ async fn serve_new_file(
         uri: &Uri,
         host: &HeaderValue,
         cfstate: &CacheFileStat,
-        volatile_etag: &EtagState,
+        volatile_etag: Option<&str>,
         resume_offset: u64,
         resume_if_range: Option<&str>,
     ) -> Request<Empty<bytes::Bytes>> {
@@ -2584,7 +2576,7 @@ async fn serve_new_file(
                 .append(CACHE_CONTROL, HeaderValue::from_static("max-age=300"));
             assert!(!r, "header does not exist by previous construction");
 
-            if let EtagState::Some(etag) = volatile_etag {
+            if let Some(etag) = volatile_etag {
                 let r = request.headers_mut().append(
                     IF_NONE_MATCH,
                     HeaderValue::try_from(etag).expect("ETag is validated by read_etag"),
@@ -2678,15 +2670,25 @@ async fn serve_new_file(
         );
     }
 
-    let volatile_etag = match &cfstate {
+    let prefetched_upstream_metadata = match &cfstate {
         CacheFileStat::Volatile {
             file,
             file_path,
             local_modification_time: _,
             prev_size: _,
-        } => EtagState::from_option(read_etag(file, file_path)),
-        CacheFileStat::New => EtagState::Unknown,
+        } => {
+            let key = cache_metadata::CacheMetadataKeyRef::new(
+                &conn_details.mirror,
+                &conn_details.debname,
+            );
+
+            Some(cache_metadata::store().resolve(&key, file, file_path))
+        }
+        CacheFileStat::New => None,
     };
+    let volatile_etag = prefetched_upstream_metadata
+        .as_ref()
+        .and_then(|m| m.etag.as_deref());
 
     // Check for a partial download file to resume (permanent files only).
     // Opens the file upfront (if it exists and is non-empty) to get size + mtime
@@ -2759,7 +2761,7 @@ async fn serve_new_file(
         &req_uri,
         host,
         &cfstate,
-        &volatile_etag,
+        volatile_etag,
         resume_offset,
         resume_if_range.as_deref(),
     );
@@ -2799,7 +2801,7 @@ async fn serve_new_file(
                 &req_uri,
                 host,
                 &cfstate,
-                &volatile_etag,
+                volatile_etag,
                 resume_offset,
                 resume_if_range.as_deref(),
             );
@@ -2845,8 +2847,15 @@ async fn serve_new_file(
 
             ibarrier.finished(file_path.clone()).await;
 
-            return serve_cached_file(conn_details, &req, file, file_path, volatile_etag, None)
-                .await;
+            return serve_cached_file(
+                conn_details,
+                &req,
+                file,
+                file_path,
+                prefetched_upstream_metadata.as_deref(),
+                None,
+            )
+            .await;
         }
 
         metrics::VOLATILE_REFETCHED_OUTOFDATE.increment();
@@ -2920,7 +2929,7 @@ async fn serve_new_file(
         // upstream's perspective this is a fresh unconditional fetch — no
         // If-Modified-Since, no If-None-Match, no Range.
         let retry_request =
-            build_fwd_request(&req_uri, host, &CacheFileStat::New, &volatile_etag, 0, None);
+            build_fwd_request(&req_uri, host, &CacheFileStat::New, volatile_etag, 0, None);
 
         fwd_response = match request_with_retry(&appstate.https_client, retry_request).await {
             Ok(r) => r,
@@ -3245,8 +3254,18 @@ async fn serve_new_file(
         );
     }
 
+    let upstream_metadata = Arc::new(UpstreamMetadata::from_upstream(
+        upstream_etag,
+        upstream_last_modified,
+    ));
+
     let dbarrier = ibarrier
-        .download(outpath.to_path_buf(), total_content_length, reservation)
+        .download(
+            outpath.to_path_buf(),
+            total_content_length,
+            reservation,
+            Arc::clone(&upstream_metadata),
+        )
         .await;
 
     {
@@ -3316,13 +3335,7 @@ async fn serve_new_file(
         }
     }
 
-    serve_downloading_file(
-        conn_details,
-        req,
-        status,
-        EtagState::from_option(upstream_etag),
-    )
-    .await
+    serve_downloading_file(conn_details, req, status, Some(&upstream_metadata)).await
 }
 
 /// Create a TCP connection to host:port, build a tunnel between the connection and
@@ -3423,15 +3436,7 @@ pub(crate) async fn process_cache_request(
                     serve_volatile_file(conn_details, req, file, cache_path, appstate).await
                 }
                 CachedFlavor::Permanent => {
-                    serve_cached_file(
-                        conn_details,
-                        &req,
-                        file,
-                        cache_path,
-                        EtagState::Unknown,
-                        None,
-                    )
-                    .await
+                    serve_cached_file(conn_details, &req, file, cache_path, None, None).await
                 }
             }
         }
@@ -3470,7 +3475,7 @@ pub(crate) async fn process_cache_request(
                         "Serving file {} already in download from mirror {} for client {}...",
                         conn_details.debname, conn_details.mirror, conn_details.client
                     );
-                    serve_downloading_file(conn_details, req, status, EtagState::Unknown).await
+                    serve_downloading_file(conn_details, req, status, None).await
                 }
             }
         }
@@ -4368,6 +4373,9 @@ async fn main_loop(
     database_task::DB_TASK_QUEUE_SENDER
         .set(db_task_tx)
         .expect("DB task queue sender initialized once");
+
+    // Process-local cache for cached-file ETag / Last-Modified xattrs.
+    cache_metadata::init().expect("cache metadata store initialized once");
 
     // Initial cache scan task
     {

--- a/src/sendfile_conn.rs
+++ b/src/sendfile_conn.rs
@@ -3,6 +3,7 @@ use std::num::NonZero;
 use std::os::fd::AsFd as _;
 use std::path::Path;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use bytes::BytesMut;
@@ -16,6 +17,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 
 use crate::cache_conditional::CacheInfo;
+use crate::cache_metadata::{self, CacheMetadataKeyRef};
 use crate::database_task::{DatabaseCommand, DbCmdDelivery, DbCmdOrigin, send_db_command};
 use crate::deb_mirror::{
     Mirror, Origin, ResourceFile, is_deb_package, is_unsafe_proxy_path, parse_request_path,
@@ -968,9 +970,9 @@ async fn try_sendfile_request(
             &conn_details,
             &aliased,
             (file, &cache_path),
-            *conn_version,
-            conn_action,
+            (*conn_version, conn_action),
             RangeRequestHeaders::extract(req.headers),
+            None,
         )
         .await;
     }
@@ -1183,11 +1185,12 @@ pub(crate) async fn serve_file_via_sendfile(
     conn_details: &ConnectionDetails,
     aliased: &str,
     source: (tokio::fs::File, &Path),
-    conn_version: ConnectionVersion,
-    conn_action: ConnectionAction,
+    conn_settings: (ConnectionVersion, ConnectionAction),
     headers: RangeRequestHeaders<'_>,
+    prefetched_upstream_metadata: Option<&cache_metadata::UpstreamMetadata>,
 ) -> SendfileResult {
     let (file, file_path) = source;
+    let (conn_version, conn_action) = conn_settings;
 
     let metadata = match file.metadata().await {
         Ok(m) => m,
@@ -1207,7 +1210,12 @@ pub(crate) async fn serve_file_via_sendfile(
 
     let file_size = metadata.len();
 
-    let cache_info = CacheInfo::read(&file, file_path, &metadata);
+    let cache_info = if let Some(meta) = prefetched_upstream_metadata {
+        CacheInfo::with_meta(&metadata, meta)
+    } else {
+        let key = CacheMetadataKeyRef::new(&conn_details.mirror, &conn_details.debname);
+        CacheInfo::resolve(&file, file_path, &metadata, &key)
+    };
 
     let (http_status, content_start, content_length, content_range, partial) =
         match evaluate_conditional_and_range(
@@ -1814,7 +1822,7 @@ pub(crate) async fn async_sendfile_unfinished(
                     // Sender dropped — download finished or aborted.
                     let st = status.read().await;
                     match *st {
-                        ActiveDownloadStatus::Finished(_) => {
+                        ActiveDownloadStatus::Finished { .. } => {
                             drop(st);
                             finished = true;
                             continue;
@@ -1825,7 +1833,7 @@ pub(crate) async fn async_sendfile_unfinished(
                                 "sendfile: upstream download aborted",
                             ));
                         }
-                        ActiveDownloadStatus::Init(_) | ActiveDownloadStatus::Download(..) => {
+                        ActiveDownloadStatus::Init(_) | ActiveDownloadStatus::Download { .. } => {
                             drop(st);
                             return Err(std::io::Error::other(
                                 "sendfile: unexpected download state for demoted client file-serve",
@@ -1850,9 +1858,9 @@ pub(crate) async fn async_sendfile_unfinished(
                 let (is_finished, is_aborted) = {
                     let st = status.read().await;
                     match *st {
-                        ActiveDownloadStatus::Finished(_) => (true, false),
+                        ActiveDownloadStatus::Finished { .. } => (true, false),
                         ActiveDownloadStatus::Aborted(_) => (false, true),
-                        ActiveDownloadStatus::Init(_) | ActiveDownloadStatus::Download(..) => {
+                        ActiveDownloadStatus::Init(_) | ActiveDownloadStatus::Download { .. } => {
                             (false, false)
                         }
                     }
@@ -1886,8 +1894,10 @@ async fn serve_unfinished_sendfile(
     headers: RangeRequestHeaders<'_>,
 ) -> SendfileResult {
     // Wait for the download to leave the Init state and learn the file path,
-    // content length, and notification receiver.
-    let (file, file_path, total_size, receiver) = {
+    // content length, notification receiver, and the upstream metadata
+    // captured on the status (so we don't need to xattr-read the temp file
+    // for ETag / Last-Modified during the conditional-request decision).
+    let (file, file_path, total_size, receiver, status_meta) = {
         let mut init_waited = false;
         loop {
             let st = dl_status.read().await;
@@ -1910,7 +1920,12 @@ async fn serve_unfinished_sendfile(
 
                     continue;
                 }
-                ActiveDownloadStatus::Download(path, cl, rx) => {
+                ActiveDownloadStatus::Download {
+                    path,
+                    content_length,
+                    rx,
+                    meta,
+                } => {
                     let file = match tokio::fs::File::open(path).await {
                         Ok(f) => f,
                         Err(err) => {
@@ -1926,15 +1941,20 @@ async fn serve_unfinished_sendfile(
                             };
                         }
                     };
-                    let r = (file, path.clone(), *cl, rx.clone());
+                    let r = (
+                        file,
+                        path.clone(),
+                        *content_length,
+                        rx.clone(),
+                        Arc::clone(meta),
+                    );
                     drop(st);
                     break r;
                 }
-                ActiveDownloadStatus::Finished(path) => {
+                ActiveDownloadStatus::Finished { path, meta, .. } => {
                     let finished_path = path.clone();
+                    let prefetched = meta.clone();
                     drop(st);
-                    // Download finished before we could join — serve the
-                    // completed file directly via sendfile.
 
                     let file = match tokio::fs::File::open(&finished_path).await {
                         Ok(f) => f,
@@ -1957,9 +1977,9 @@ async fn serve_unfinished_sendfile(
                         conn_details,
                         aliased,
                         (file, &finished_path),
-                        conn_version,
-                        conn_action,
+                        (conn_version, conn_action),
                         headers,
+                        prefetched.as_deref(),
                     )
                     .await;
                 }
@@ -2004,7 +2024,10 @@ async fn serve_unfinished_sendfile(
         }
     };
 
-    let cache_info = CacheInfo::read(&file, &file_path, &metadata);
+    // Late-joiner: use the in-flight metadata captured from the active-
+    // downloads status (no xattr reads — the temp file may still be
+    // having its xattrs written concurrently).
+    let cache_info = CacheInfo::with_meta(&metadata, &status_meta);
 
     // Range handling uses the total upstream size (not the current partial size on disk).
     let (http_status, content_start, content_length, content_range, partial) =

--- a/src/splice_conn.rs
+++ b/src/splice_conn.rs
@@ -63,9 +63,9 @@ use crate::utils::{
 use crate::{
     APP_USER_AGENT, APP_VIA, ActiveDownloadStatus, AppState, CachedFlavor, ConnectionDetails,
     ContentLength, Never, OriginateOutcome, SCHEME_CACHE, Scheme, SchemeKey, SchemeKeyRef,
-    VOLATILE_UNKNOWN_CONTENT_LENGTH_UPPER, client_counter, content_type_for_cached_file,
-    global_cache_quota, global_config, is_host_allowed_cached, metrics, static_assert,
-    warn_once_or_debug, warn_once_or_info,
+    VOLATILE_UNKNOWN_CONTENT_LENGTH_UPPER, cache_metadata, client_counter,
+    content_type_for_cached_file, global_cache_quota, global_config, is_host_allowed_cached,
+    metrics, static_assert, warn_once_or_debug, warn_once_or_info,
 };
 #[cfg(feature = "ktls")]
 use crate::{KTLS_BLOCKED, warn_once};
@@ -3687,7 +3687,14 @@ async fn splice_proxy_drive(
                 .modified()
                 .expect("Platform should support modification timestamps via setup check");
             let if_modified_since = HttpDate::from(mtime).format();
-            let if_none_match = read_etag(&file, &cache_path);
+            let key = cache_metadata::CacheMetadataKeyRef::new(
+                &conn_details.mirror,
+                &conn_details.debname,
+            );
+            let if_none_match = cache_metadata::store()
+                .resolve(&key, &file, &cache_path)
+                .etag
+                .clone();
             volatile_cond = Some(VolatileCondHeaders {
                 if_modified_since,
                 if_none_match,
@@ -3791,9 +3798,9 @@ async fn splice_proxy_drive(
                 conn_details,
                 "",
                 (file, &cache_path),
-                conn_version,
-                conn_action,
+                (conn_version, conn_action),
                 client_range,
+                None,
             )
             .await
             {
@@ -4003,9 +4010,9 @@ async fn splice_proxy_drive(
             conn_details,
             "",
             (file, &cache_path),
-            conn_version,
-            conn_action,
+            (conn_version, conn_action),
             client_range,
+            None,
         )
         .await
         {
@@ -4492,11 +4499,16 @@ async fn splice_proxy_drive(
         write_last_modified(&tempfile, &temppath, lm);
     }
 
+    let download_meta = cache_metadata::UpstreamMetadata::from_upstream(
+        upstream_resp.etag.clone(),
+        upstream_resp.last_modified.clone(),
+    );
     let mut dbarrier = ibarrier
         .download(
             temppath.to_path_buf(),
             ContentLength::Exact(total_content_length),
             reservation,
+            Arc::new(download_meta),
         )
         .await;
 
@@ -5413,12 +5425,18 @@ async fn handle_volatile_buffered_download(
         write_last_modified(&tempfile, &temppath, lm);
     }
 
+    let download_meta = cache_metadata::UpstreamMetadata::from_upstream(
+        upstream_resp.etag.clone(),
+        upstream_resp.last_modified.clone(),
+    );
+
     // Transition barrier: InitBarrier → DownloadBarrier.
     let mut dbarrier: DownloadBarrier = ibarrier
         .download(
             temppath.to_path_buf(),
             ContentLength::Exact(total_content_length),
             reservation,
+            Arc::new(download_meta),
         )
         .await;
 

--- a/src/task_cleanup.rs
+++ b/src/task_cleanup.rs
@@ -22,7 +22,7 @@ use tokio::io::{AsyncSeekExt as _, AsyncWriteExt as _};
 
 use crate::{
     AppState, CachedFlavor, ClientInfo, ConnectionDetails, ProxyCacheBody, ProxyCacheError,
-    RETENTION_TIME,
+    RETENTION_TIME, cache_metadata,
     database::{MirrorEntry, OriginEntry},
     deb_mirror::{Mirror, UriFormat as _, mirror_cache_path_impl},
     global_cache_quota, global_config,
@@ -587,6 +587,16 @@ async fn cleanup_mirror_deb_files(
                 path.display()
             );
             continue;
+        }
+
+        // Drop the post-flight ETag/Last-Modified entry for the removed
+        // file so a subsequent re-cache starts from a clean state instead
+        // of reusing the stale entry until the next rename.  Treat a
+        // non-UTF-8 filename as opaque (debnames are URL-decoded ASCII in
+        // practice; an OsString that doesn't decode is not in the map).
+        if let Some(debname) = path.file_name().and_then(|n| n.to_str()) {
+            cache_metadata::store()
+                .invalidate(&cache_metadata::CacheMetadataKeyRef::new(&mirror, debname));
         }
 
         debug!("Removed unreferenced file `{}`", path.display());

--- a/src/web_interface.rs
+++ b/src/web_interface.rs
@@ -22,7 +22,7 @@ use time::{OffsetDateTime, format_description::FormatItem, macros::format_descri
 
 use crate::{
     APP_NAME, APP_VERSION, AppState, HumanFmt, LOGSTORE, ProxyCacheBody, RUNTIMEDETAILS,
-    RuntimeDetails,
+    RuntimeDetails, cache_metadata,
     client_counter::{active_client_downloads, connected_clients},
     config::HttpsUpgradeMode,
     database::{Database, MirrorStatEntry},
@@ -1235,6 +1235,11 @@ fn build_daemon_status_html(
             metrics::DB_MIRROR_CACHE_MISSES.get(),
             metrics::DB_MIRROR_LAST_SEEN_FLUSHED.get(),
         ),
+    );
+    t.row_tip(
+        "Metadata Cache Entries",
+        "Process-local entries cached from per-file ETag and Last-Modified xattrs. Skips fgetxattr(2) on subsequent conditional-request hits; rebuilt lazily after restart.",
+        cache_metadata::store().len(),
     );
     t.row(
         "Log Entries",

--- a/src/xattr_helpers.rs
+++ b/src/xattr_helpers.rs
@@ -37,51 +37,81 @@ pub(crate) fn remove_helper(file: &tokio::fs::File, display_path: &Path, key: &s
     }
 }
 
+/// Marker returned by [`try_read_helper`] (and the typed wrappers in
+/// [`crate::http_etag`] / [`crate::http_last_modified`]) when the xattr
+/// syscall failed in a way that may succeed on retry — distinct from a
+/// stable "no value" outcome (xattr absent, filesystem doesn't support
+/// xattrs, or a malformed value was scrubbed).  Callers that don't need
+/// the distinction can use the non-`try_` variants which collapse both
+/// outcomes to `None`; callers that negative-cache (see
+/// [`crate::cache_metadata`]) must use the `try_` variants and skip the
+/// cache write on `Err`.
+#[derive(Debug)]
+pub(crate) struct XattrIoError;
+
+/// Read the extended attribute value for the given key, distinguishing
+/// transient I/O errors from a stable "no value" outcome.
+///
+/// - `Ok(Some(s))` — xattr present and decoded as UTF-8.
+/// - `Ok(None)` — xattr absent, FS does not support xattrs, or the value
+///   was malformed (invalid UTF-8) and has been scrubbed.  Safe to
+///   negative-cache.
+/// - `Err(XattrIoError)` — transient syscall failure (warning is logged
+///   here).  Callers must NOT cache the absence; the next request may
+///   succeed.
+pub(crate) fn try_read_helper(
+    file: &tokio::fs::File,
+    display_path: &Path,
+    key: &str,
+) -> Result<Option<String>, XattrIoError> {
+    let data = tokio::task::block_in_place(|| XattrFile(file).get_xattr(key));
+
+    match data {
+        Ok(None) => Ok(None),
+
+        Ok(Some(val)) => match String::from_utf8(val) {
+            Ok(s) => Ok(Some(s)),
+            Err(err @ std::string::FromUtf8Error { .. }) => {
+                warn!(
+                    "Discarding invalid UTF-8 xattr from `{}` for key `{key}`:  {err}",
+                    display_path.display()
+                );
+
+                remove_helper(file, display_path, key);
+
+                Ok(None)
+            }
+        },
+
+        Err(err) => {
+            let kind = err.kind();
+            if kind == std::io::ErrorKind::Unsupported
+                || err.raw_os_error() == Some(Errno::ENODATA as i32)
+            {
+                Ok(None)
+            } else {
+                warn!(
+                    "Unexpected error reading xattr from `{}` for key `{key}`:  {err}",
+                    display_path.display()
+                );
+                Err(XattrIoError)
+            }
+        }
+    }
+}
+
 /// Read the extended attribute value for the given key from the file.
 ///
-/// Returns `None` on any error (graceful degradation).
+/// Returns `None` on any error (graceful degradation).  Callers that
+/// need to distinguish transient I/O errors from a stable "no value"
+/// outcome (e.g. for negative caching) should use [`try_read_helper`].
 #[must_use]
 pub(crate) fn read_helper(
     file: &tokio::fs::File,
     display_path: &Path,
     key: &str,
 ) -> Option<String> {
-    let data = tokio::task::block_in_place(|| XattrFile(file).get_xattr(key));
-
-    match data {
-        Ok(None) => None,
-
-        Ok(Some(val)) => {
-            let s = match String::from_utf8(val) {
-                Ok(s) => s,
-                Err(err @ std::string::FromUtf8Error { .. }) => {
-                    warn!(
-                        "Discarding invalid UTF-8 xattr from `{}` for key `{key}`:  {err}",
-                        display_path.display()
-                    );
-
-                    remove_helper(file, display_path, key);
-
-                    return None;
-                }
-            };
-
-            Some(s)
-        }
-
-        Err(err) => {
-            let kind = err.kind();
-            if kind != std::io::ErrorKind::Unsupported
-                && err.raw_os_error() != Some(Errno::ENODATA as i32)
-            {
-                warn!(
-                    "Unexpected error reading xattr from `{}` for key `{key}`:  {err}",
-                    display_path.display()
-                );
-            }
-            None
-        }
-    }
+    try_read_helper(file, display_path, key).ok().flatten()
 }
 
 /// Write the given value to the extended attribute for the given key on the file.


### PR DESCRIPTION
Every cache-hit conditional-request path called read_etag and read_last_modified, each issuing one fgetxattr(2) on the cached file.  Profiling showed the rustix bounds-check inside the xattr crate (`<isize as PartialOrd>::le` with `xattr::FileExt::get_xattr` as ancestor) at 0.49% of worker leaf samples, plus the reads drove `block_in_place` and `spawn_blocking_inner` mutex traffic in the runtime.

A simple `(mirror, debname)` -> meta cache is unsafe to populate during a download: a stale-volatile re-fetch could publish NEW upstream values while a worker still served OLD bytes from the pre-rename file, and a worker reading the cache after the rename but before active_downloads removal would see NEW for the brief window in between.

Split the data sources by lifecycle:

* In-flight: ActiveDownloadStatus::Download and Finished now carry an UpstreamMetadata (etag + parsed Last-Modified pair) embedded on the variant.  InitBarrier::download takes the metadata so it flows in the same write that publishes the new status; late joiners read from status and never touch xattr.

* Post-flight: a new in-process CacheMetadataStore mapping `(mirror, debname)` -> Arc<UpstreamMetadata>.  Lookups are zero-clone via a CacheMetadataKeyRef + Equivalent impl mirroring the ActiveDownloadKeyRef pattern; the owned key only materialises on the cold cache-miss insert.  resolve() lazy-loads from xattr on miss; subsequent hits are an Arc clone under a parking_lot RwLock read.

* Hand-off: RenameBarrier::release publishes the in-flight metadata to the cache *before* removing the active-downloads entry, so no worker can observe "no active entry, cache=OLD".

xattr writes during the download path are unchanged — they remain the persistent source of truth and let the cache lazy-load after restarts.  read_etag/read_last_modified stay as-is for the partial- file resume validation in main.rs:2715 and splice_conn.rs:3677, where the temp file's xattr is the relevant value.

Cleanup hook in task_cleanup.rs invalidates the cache key after removing each unreferenced .deb so a future re-cache starts clean instead of carrying a stale entry until the next rename.  The abort/scopeguard/failed-rename paths intentionally don't invalidate because the cache was never written for that key during the in-flight phase.