### PR TITLE
task_cleanup: verify cached deb checksums against Packages stanzas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "rustls",
  "scopeguard",
  "serde",
+ "sha2 0.11.0",
  "simplelog",
  "smallvec",
  "sqlx",
@@ -248,6 +249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -403,6 +413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,7 +532,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -541,10 +566,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -905,7 +941,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -961,6 +997,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1322,7 +1367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1855,8 +1900,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -2067,7 +2112,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2078,7 +2123,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2103,7 +2159,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2206,7 +2262,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror",
  "tokio",
@@ -2243,7 +2299,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-sqlite",
  "syn",
@@ -2263,7 +2319,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -2283,7 +2339,7 @@ dependencies = [
  "rand 0.8.6",
  "rsa",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -2320,7 +2376,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tokio-native-tls = { version = "0.3", optional = true }
 tokio-rustls = { version = "0.26", optional = true }
 scopeguard = "1.2.0"
 serde = "1.0.197"
+sha2 = "0.11"
 simplelog = "0.12.1"
 smallvec = { version = "1.15", features = ["const_generics", "union"] }
 sqlx = { version = "0.8", default-features = false, features = [

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -530,6 +530,12 @@ pub(crate) static DB_MIRROR_CACHE_ENTRIES: StateU64 = StateU64::new();
 pub(crate) static CLEANUP_EVICTIONS: Accumulator = Accumulator::new();
 /// Total bytes reclaimed across all cleanup runs.
 pub(crate) static CLEANUP_BYTES_RECLAIMED: Accumulator = Accumulator::new();
+/// Cache files removed by cleanup because their content hash did not match the
+/// value advertised in the upstream Packages stanza. A non-zero counter
+/// indicates either disk corruption, an upstream mirror returning a different
+/// build than its index claims, or a stale cache file whose origin re-issued
+/// the same `Filename:` under a different content.
+pub(crate) static CLEANUP_CHECKSUM_MISMATCHES: Counter = Counter::new();
 
 /// Last cleanup run: duration in seconds (atomically updated; readers may
 /// observe a transient mix across the trio between updates).

--- a/src/task_cleanup.rs
+++ b/src/task_cleanup.rs
@@ -2,6 +2,7 @@ use std::{
     ffi::OsString,
     io::ErrorKind,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    os::unix::fs::OpenOptionsExt as _,
     path::{Path, PathBuf},
     sync::{
         LazyLock,
@@ -114,6 +115,319 @@ fn parse_filename_field(line: &str) -> Option<&std::ffi::OsStr> {
     Path::new(filepath).file_name()
 }
 
+/// Decode `hex` into exactly `N` bytes. Returns `None` on wrong length or any
+/// non-hexadecimal byte. Accepts upper- and lower-case (Debian uses lowercase
+/// but real-world Packages indices have occasionally mixed case).
+fn hex_decode_exact<const N: usize>(hex: &str) -> Option<[u8; N]> {
+    if hex.len() != N * 2 {
+        return None;
+    }
+    let bytes = hex.as_bytes();
+    let mut out = [0u8; N];
+    let mut i = 0;
+    while i < N {
+        let hi = hex_digit(bytes[2 * i])?;
+        let lo = hex_digit(bytes[2 * i + 1])?;
+        out[i] = (hi << 4) | lo;
+        i += 1;
+    }
+    Some(out)
+}
+
+const fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Parse a Packages stanza line of the form `"<prefix><hex>"` into a fixed-size
+/// byte array. Returns `None` if the line does not carry the expected prefix
+/// or the hex payload is malformed.
+fn parse_hex_field<const N: usize>(line: &str, prefix: &str) -> Option<[u8; N]> {
+    let rest = line.trim().strip_prefix(prefix)?.trim_start();
+    hex_decode_exact::<N>(rest)
+}
+
+/// Lowercase-hex encoding suitable for log messages.
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(char::from(HEX[(*b >> 4) as usize]));
+        out.push(char::from(HEX[(*b & 0x0f) as usize]));
+    }
+    out
+}
+
+/// Hash algorithm we accept from Debian `Packages` stanzas. SHA256 is the
+/// universal default in modern indices; SHA512 is used as a fallback when
+/// SHA256 is missing.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum HashAlgo {
+    Sha256,
+    Sha512,
+}
+
+impl HashAlgo {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Sha256 => "SHA256",
+            Self::Sha512 => "SHA512",
+        }
+    }
+}
+
+/// Outcome of verifying a cache file against an expected digest.
+#[derive(Debug)]
+enum Verdict {
+    /// Computed digest equals the expected one.
+    Match,
+    /// Computed digest differs from the expected one and the underlying file
+    /// did not change inode/size during hashing.
+    Mismatch { computed: Vec<u8> },
+    /// The file's `(inode, size)` changed between hash start and finish, so a
+    /// concurrent writer raced us; the cleanup leaves the file alone.
+    Raced,
+    /// Open/read failed; cleanup leaves the file alone.
+    IoError(std::io::Error),
+}
+
+/// Per-call context for [`PackageFormat::reduce_file_list`]: needed to invalidate
+/// per-file `cache_metadata` entries and to attribute checksum-mismatch
+/// removals back to the per-mirror `CleanupDone` totals.
+struct ReduceContext<'a> {
+    mirror: &'a Mirror,
+    layout: CacheLayout,
+    mismatch_files: &'a mut u64,
+    mismatch_bytes: &'a mut u64,
+}
+
+/// Accumulated state of the current Debian `Packages` stanza.
+#[derive(Debug)]
+struct Stanza {
+    filename: Option<OsString>,
+    sha256: Option<[u8; 32]>,
+    sha512: Option<[u8; 64]>,
+}
+
+impl Stanza {
+    const fn new() -> Self {
+        Self {
+            filename: None,
+            sha256: None,
+            sha512: None,
+        }
+    }
+
+    const fn is_empty(&self) -> bool {
+        self.filename.is_none() && self.sha256.is_none() && self.sha512.is_none()
+    }
+
+    fn reset(&mut self) {
+        self.filename = None;
+        self.sha256 = None;
+        self.sha512 = None;
+    }
+
+    fn ingest(&mut self, line: &str) {
+        if self.filename.is_none()
+            && let Some(name) = parse_filename_field(line)
+        {
+            self.filename = Some(name.to_os_string());
+            return;
+        }
+        if self.sha256.is_none()
+            && let Some(h) = parse_hex_field::<32>(line, "SHA256: ")
+        {
+            self.sha256 = Some(h);
+            return;
+        }
+        if self.sha512.is_none()
+            && let Some(h) = parse_hex_field::<64>(line, "SHA512: ")
+        {
+            self.sha512 = Some(h);
+        }
+    }
+
+    /// Preferred (algo, expected-digest) pair: SHA256 wins, SHA512 is the
+    /// fallback, `None` means the stanza advertised no usable checksum.
+    fn chosen(&self) -> Option<(HashAlgo, Vec<u8>)> {
+        if let Some(h) = self.sha256 {
+            Some((HashAlgo::Sha256, h.to_vec()))
+        } else {
+            self.sha512.map(|h| (HashAlgo::Sha512, h.to_vec()))
+        }
+    }
+}
+
+/// Hash the contents of an open file using the given digest algorithm.
+/// Synchronous code, blocking the current thread.
+fn hash_open_file<D: sha2::Digest>(file: &mut std::fs::File) -> std::io::Result<Vec<u8>> {
+    use std::io::Read as _;
+
+    let mut hasher = D::new();
+    #[expect(clippy::large_stack_arrays, reason = "ensure efficient file hashing")]
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize().to_vec())
+}
+
+/// Blocking digest-and-compare with an inode/size race check after hashing.
+/// Runs on the blocking pool via [`verify_cache_file`].
+fn verify_file_sync(path: &Path, algo: HashAlgo, expected: &[u8]) -> Verdict {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let mut file = match std::fs::File::options()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(err) => return Verdict::IoError(err),
+    };
+    let pre_meta = match file.metadata() {
+        Ok(m) => m,
+        Err(err) => return Verdict::IoError(err),
+    };
+    let pre_ino = pre_meta.ino();
+    let pre_size = pre_meta.len();
+
+    let computed = match algo {
+        HashAlgo::Sha256 => match hash_open_file::<sha2::Sha256>(&mut file) {
+            Ok(h) => h,
+            Err(err) => return Verdict::IoError(err),
+        },
+        HashAlgo::Sha512 => match hash_open_file::<sha2::Sha512>(&mut file) {
+            Ok(h) => h,
+            Err(err) => return Verdict::IoError(err),
+        },
+    };
+
+    if computed.as_slice() == expected {
+        return Verdict::Match;
+    }
+
+    // Race check: a fresh download finishing mid-hash either replaces the
+    // file via rename (different inode) or rewrites it in place (size change).
+    // Either way our digest is for content no longer at `path`, so bail.
+    if let Ok(post_meta) = std::fs::metadata(path)
+        && (post_meta.ino() != pre_ino || post_meta.len() != pre_size)
+    {
+        return Verdict::Raced;
+    }
+    Verdict::Mismatch { computed }
+}
+
+async fn verify_cache_file(path: PathBuf, algo: HashAlgo, expected: Vec<u8>) -> Verdict {
+    match tokio::task::spawn_blocking(move || verify_file_sync(&path, algo, &expected)).await {
+        Ok(v) => v,
+        Err(join_err) => Verdict::IoError(std::io::Error::other(join_err)),
+    }
+}
+
+/// Process one stanza: if its `Filename:` basename matches a candidate
+/// cached file, verify the file content and either retain it (match), warn-
+/// and-retain it (no usable hash advertised, transient error, or concurrent
+/// rename race), or warn-and-evict it (genuine digest mismatch).
+async fn flush_stanza(
+    stanza: &mut Stanza,
+    file_list: &mut HashMap<OsString, PathBuf>,
+    ctx: &mut ReduceContext<'_>,
+) {
+    let Some(filename) = stanza.filename.take() else {
+        stanza.reset();
+        return;
+    };
+    let Some(path) = file_list.get(&filename).cloned() else {
+        stanza.reset();
+        return;
+    };
+
+    match stanza.chosen() {
+        None => {
+            warn!(
+                "Packages stanza for `{}` advertises no SHA256/SHA512; retaining cache file `{}` without verification",
+                Path::new(&filename).display(),
+                path.display(),
+            );
+            file_list.remove(&filename);
+        }
+        Some((algo, expected)) => {
+            let pre_size = match tokio::fs::metadata(&path).await {
+                Ok(m) => m.len(),
+                Err(err) => {
+                    error!(
+                        "Failed to stat cache file `{}` before {} verification:  {err}; retaining",
+                        path.display(),
+                        algo.as_str(),
+                    );
+                    file_list.remove(&filename);
+                    stanza.reset();
+                    return;
+                }
+            };
+            match verify_cache_file(path.clone(), algo, expected.clone()).await {
+                Verdict::Match => {
+                    file_list.remove(&filename);
+                }
+                Verdict::Mismatch { computed } => {
+                    warn!(
+                        "Cache file `{}` failed {} verification: expected={}, computed={}",
+                        path.display(),
+                        algo.as_str(),
+                        hex_encode(&expected),
+                        hex_encode(&computed),
+                    );
+                    if let Err(err) = tokio::fs::remove_file(&path).await {
+                        error!(
+                            "Error removing checksum-mismatched cache file `{}`:  {err}",
+                            path.display()
+                        );
+                    } else {
+                        if let Some(debname) = path.file_name().and_then(|n| n.to_str()) {
+                            cache_metadata::store().invalidate(
+                                &cache_metadata::CacheMetadataKeyRef::new(
+                                    ctx.mirror, debname, ctx.layout,
+                                ),
+                            );
+                        }
+                        metrics::CLEANUP_CHECKSUM_MISMATCHES.increment();
+                        *ctx.mismatch_files += 1;
+                        *ctx.mismatch_bytes += pre_size;
+                    }
+                    file_list.remove(&filename);
+                }
+                Verdict::Raced => {
+                    warn!(
+                        "Cache file `{}` changed during {} verification; retaining (concurrent re-cache)",
+                        path.display(),
+                        algo.as_str(),
+                    );
+                    file_list.remove(&filename);
+                }
+                Verdict::IoError(err) => {
+                    error!(
+                        "Failed to {} cache file `{}`:  {err}; retaining",
+                        algo.as_str(),
+                        path.display(),
+                    );
+                    file_list.remove(&filename);
+                }
+            }
+        }
+    }
+    stanza.reset();
+}
+
 #[derive(Clone, Copy)]
 enum PackageFormat {
     Raw,
@@ -131,12 +445,15 @@ impl PackageFormat {
         }
     }
 
-    // TODO: verify hashes
+    /// Stream a (possibly compressed) Debian `Packages` file stanza by stanza,
+    /// reducing the candidate `file_list` by basename and verifying matched
+    /// cache files against the stanza's `SHA256:`/`SHA512:` digest.
     async fn reduce_file_list(
         self,
         file: tokio::fs::File,
         filename: &str,
         file_list: &mut HashMap<OsString, PathBuf>,
+        ctx: &mut ReduceContext<'_>,
         config: &Config,
     ) -> Result<(), ProxyCacheError> {
         debug_assert!(!file_list.is_empty(), "avoid unnecessary work");
@@ -160,23 +477,31 @@ impl PackageFormat {
         };
 
         let mut buffer = String::with_capacity(128);
+        let mut stanza = Stanza::new();
         loop {
             buffer.clear();
             match reader.read_line(&mut buffer).await {
-                Ok(0) => return Ok(()), // EOF
+                Ok(0) => {
+                    // Flush the final stanza if the Packages file doesn't end
+                    // with a blank line.
+                    if !stanza.is_empty() {
+                        flush_stanza(&mut stanza, file_list, ctx).await;
+                    }
+                    return Ok(());
+                }
                 Err(err) => {
                     error!("Failed to read in-memory file `{filename}`:  {err}");
                     return Err(err.into());
                 }
                 Ok(_bytes_read) => {
-                    let Some(filename) = parse_filename_field(&buffer) else {
+                    if buffer.trim().is_empty() {
+                        flush_stanza(&mut stanza, file_list, ctx).await;
+                        if file_list.is_empty() {
+                            return Ok(());
+                        }
                         continue;
-                    };
-
-                    if file_list.remove(filename).is_some() && file_list.is_empty() {
-                        // No files left to potentially remove
-                        return Ok(());
                     }
+                    stanza.ingest(&buffer);
                 }
             }
         }
@@ -477,6 +802,9 @@ async fn cleanup_mirror_deb_files(
         });
     }
 
+    let mut mismatch_files: u64 = 0;
+    let mut mismatch_bytes: u64 = 0;
+
     for origin in &active_origins {
         let (mut response, pkgfmt) = match get_package_file(&mirror, origin, &appstate).await {
             // A missing Packages file leaves us unable to complete the
@@ -490,9 +818,9 @@ async fn cleanup_mirror_deb_files(
 
                 return Ok(CleanupDone {
                     mirror,
-                    files_retained: num_total_files,
-                    files_removed: 0,
-                    bytes_removed: 0,
+                    files_retained: num_total_files - mismatch_files,
+                    files_removed: mismatch_files,
+                    bytes_removed: mismatch_bytes,
                 });
             }
             Ok(r) => r,
@@ -534,22 +862,30 @@ async fn cleanup_mirror_deb_files(
                 error!("Failed to write response to in-memory file `{memfdname}`:  {err}");
             })?;
 
-        pkgfmt
-            .reduce_file_list(file, &memfdname, &mut cached_files, config)
-            .await?;
+        {
+            let mut ctx = ReduceContext {
+                mirror: &mirror,
+                layout: CacheLayout::StructuredPool,
+                mismatch_files: &mut mismatch_files,
+                mismatch_bytes: &mut mismatch_bytes,
+            };
+            pkgfmt
+                .reduce_file_list(file, &memfdname, &mut cached_files, &mut ctx, config)
+                .await?;
+        }
 
         if cached_files.is_empty() {
             return Ok(CleanupDone {
                 mirror,
-                files_retained: num_total_files,
-                files_removed: 0,
-                bytes_removed: 0,
+                files_retained: num_total_files - mismatch_files,
+                files_removed: mismatch_files,
+                bytes_removed: mismatch_bytes,
             });
         }
     }
 
-    let mut bytes_removed = 0;
-    let mut files_removed = 0;
+    let mut aged_files: u64 = 0;
+    let mut aged_bytes: u64 = 0;
     let now = SystemTime::now();
 
     for path in cached_files.values() {
@@ -631,14 +967,17 @@ async fn cleanup_mirror_deb_files(
 
         debug!("Removed unreferenced file `{}`", path.display());
 
-        bytes_removed += size;
-        files_removed += 1;
+        aged_bytes += size;
+        aged_files += 1;
     }
 
     info!(
-        "Removed {files_removed} unreferenced deb files for mirror {mirror} ({})",
-        HumanFmt::Size(bytes_removed)
+        "Removed {aged_files} unreferenced deb files for mirror {mirror} ({})",
+        HumanFmt::Size(aged_bytes)
     );
+
+    let files_removed = mismatch_files + aged_files;
+    let bytes_removed = mismatch_bytes + aged_bytes;
 
     Ok(CleanupDone {
         mirror,
@@ -921,20 +1260,30 @@ async fn cleanup_mirror_flat_files(
             error!("Failed to write response to in-memory file `{memfdname}`:  {err}");
         })?;
 
-    pkgfmt
-        .reduce_file_list(file, &memfdname, &mut cached_files, config)
-        .await?;
+    let mut mismatch_files: u64 = 0;
+    let mut mismatch_bytes: u64 = 0;
+    {
+        let mut ctx = ReduceContext {
+            mirror: &mirror,
+            layout: CacheLayout::Flat,
+            mismatch_files: &mut mismatch_files,
+            mismatch_bytes: &mut mismatch_bytes,
+        };
+        pkgfmt
+            .reduce_file_list(file, &memfdname, &mut cached_files, &mut ctx, config)
+            .await?;
+    }
 
     if cached_files.is_empty() {
         return Ok(CleanupDone {
             mirror,
-            files_retained: num_total_files,
-            files_removed: 0,
-            bytes_removed: 0,
+            files_retained: num_total_files - mismatch_files,
+            files_removed: mismatch_files,
+            bytes_removed: mismatch_bytes,
         });
     }
 
-    let (files_removed, bytes_removed) = sweep_aged_cached_debs(
+    let (aged_files, aged_bytes) = sweep_aged_cached_debs(
         &cached_files,
         UNREFERENCED_KEEP_SPAN,
         &mirror,
@@ -942,9 +1291,12 @@ async fn cleanup_mirror_flat_files(
     )
     .await;
 
+    let files_removed = mismatch_files + aged_files;
+    let bytes_removed = mismatch_bytes + aged_bytes;
+
     info!(
-        "Removed {files_removed} unreferenced flat deb files for mirror {mirror} ({})",
-        HumanFmt::Size(bytes_removed)
+        "Removed {aged_files} unreferenced flat deb files for mirror {mirror} ({})",
+        HumanFmt::Size(aged_bytes)
     );
 
     Ok(CleanupDone {
@@ -1287,5 +1639,143 @@ mod tests {
         assert_eq!(parse_filename_field("Package: stub\n"), None);
         assert_eq!(parse_filename_field("\n"), None);
         assert_eq!(parse_filename_field(""), None);
+    }
+
+    #[test]
+    fn hex_decode_exact_round_trip_lowercase() {
+        let bytes: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+        let s = hex_encode(&bytes);
+        assert_eq!(s, "deadbeef");
+        assert_eq!(hex_decode_exact::<4>(&s), Some(bytes));
+    }
+
+    #[test]
+    fn hex_decode_exact_accepts_uppercase() {
+        assert_eq!(
+            hex_decode_exact::<4>("DEADBEEF"),
+            Some([0xde, 0xad, 0xbe, 0xef])
+        );
+    }
+
+    #[test]
+    fn hex_decode_exact_rejects_wrong_length() {
+        assert_eq!(hex_decode_exact::<4>("deadbe"), None); // too short
+        assert_eq!(hex_decode_exact::<4>("deadbeef00"), None); // too long
+    }
+
+    #[test]
+    fn hex_decode_exact_rejects_non_hex() {
+        assert_eq!(hex_decode_exact::<4>("deadbeeg"), None);
+        assert_eq!(hex_decode_exact::<4>("deadbe!f"), None);
+    }
+
+    #[test]
+    fn parse_hex_field_sha256() {
+        let hash = [0x11u8; 32];
+        let line = format!("SHA256: {}\n", hex_encode(&hash));
+        assert_eq!(parse_hex_field::<32>(&line, "SHA256: "), Some(hash));
+    }
+
+    #[test]
+    fn parse_hex_field_sha512() {
+        let hash = [0x22u8; 64];
+        let line = format!("SHA512:  {}\r\n", hex_encode(&hash));
+        assert_eq!(parse_hex_field::<64>(&line, "SHA512: "), Some(hash));
+    }
+
+    #[test]
+    fn parse_hex_field_rejects_wrong_prefix() {
+        let line = format!("MD5sum: {}\n", hex_encode(&[0u8; 32]));
+        assert_eq!(parse_hex_field::<32>(&line, "SHA256: "), None);
+    }
+
+    #[test]
+    fn parse_hex_field_rejects_malformed_payload() {
+        // 63 hex chars (one short of 64); should fail length check.
+        let payload = "0".repeat(63);
+        let line = format!("SHA256: {payload}\n");
+        assert_eq!(parse_hex_field::<32>(&line, "SHA256: "), None);
+    }
+
+    #[test]
+    fn stanza_ingest_collects_filename_and_sha256() {
+        let mut s = Stanza::new();
+        s.ingest("Filename: pool/main/a/abc/abc_1.0_amd64.deb\n");
+        s.ingest(&format!("SHA256: {}\n", hex_encode(&[0xab; 32])));
+        assert_eq!(s.filename.as_deref(), Some(OsStr::new("abc_1.0_amd64.deb")));
+        assert_eq!(s.chosen(), Some((HashAlgo::Sha256, vec![0xab; 32])));
+    }
+
+    #[test]
+    fn stanza_chosen_prefers_sha256_over_sha512() {
+        let mut s = Stanza::new();
+        s.sha256 = Some([0x11u8; 32]);
+        s.sha512 = Some([0x22u8; 64]);
+        assert_eq!(s.chosen(), Some((HashAlgo::Sha256, vec![0x11u8; 32])));
+    }
+
+    #[test]
+    fn stanza_chosen_falls_back_to_sha512() {
+        let mut s = Stanza::new();
+        s.sha512 = Some([0x33u8; 64]);
+        assert_eq!(s.chosen(), Some((HashAlgo::Sha512, vec![0x33u8; 64])));
+    }
+
+    #[test]
+    fn stanza_chosen_returns_none_without_hash() {
+        let s = Stanza::new();
+        assert_eq!(s.chosen(), None);
+    }
+
+    #[test]
+    fn stanza_ingest_ignores_unrelated_lines() {
+        let mut s = Stanza::new();
+        s.ingest("Package: stub\n");
+        s.ingest("Description: a stub\n");
+        s.ingest(" continued description text\n");
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn verify_file_sync_match_and_mismatch() {
+        use sha2::Digest as _;
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("cache.deb");
+        let payload = b"hello apt-cacher-rs world";
+        {
+            let mut f = std::fs::File::create(&path).expect("create");
+            f.write_all(payload).expect("write");
+        }
+
+        let expected_sha256 = sha2::Sha256::digest(payload).to_vec();
+        assert!(matches!(
+            verify_file_sync(&path, HashAlgo::Sha256, &expected_sha256),
+            Verdict::Match
+        ));
+
+        let wrong: Vec<u8> = vec![0u8; 32];
+        let v = verify_file_sync(&path, HashAlgo::Sha256, &wrong);
+        let Verdict::Mismatch { computed } = v else {
+            unreachable!("expected Mismatch verdict, got {v:?}")
+        };
+        assert_eq!(computed, expected_sha256);
+
+        let expected_sha512 = sha2::Sha512::digest(payload).to_vec();
+        assert!(matches!(
+            verify_file_sync(&path, HashAlgo::Sha512, &expected_sha512),
+            Verdict::Match
+        ));
+    }
+
+    #[test]
+    fn verify_file_sync_io_error_on_missing_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does_not_exist");
+        assert!(matches!(
+            verify_file_sync(&missing, HashAlgo::Sha256, &[0u8; 32]),
+            Verdict::IoError(_)
+        ));
     }
 }

--- a/src/web_interface.rs
+++ b/src/web_interface.rs
@@ -1911,6 +1911,11 @@ fn build_metrics_html() -> String {
         ),
     );
     t.row_tip(
+        "Cleanup Checksum Mismatches",
+        "Cache files removed because their content hash did not match the SHA256/SHA512 advertised in the upstream Packages stanza. Non-zero indicates corruption or a mirror inconsistency.",
+        AlertNonzero(metrics::CLEANUP_CHECKSUM_MISMATCHES.get()),
+    );
+    t.row_tip(
         "Last Cleanup",
         "Duration, files removed and bytes reclaimed by the most recent cache-cleanup run.",
         format_args!(


### PR DESCRIPTION
Cleanup now parses each Debian Packages stanza for SHA256 (with SHA512 fallback) in addition to Filename: and verifies matching cache files against the advertised digest. Files whose content matches are retained; mismatched files are warned and removed; stanzas without a usable hash emit a warn and the file is retained. Adds a CLEANUP_CHECKSUM_MISMATCHES metric surfaced on the dashboard, and resolves the long-standing "// TODO: verify hashes" marker in task_cleanup.rs.