### PR TITLE
Avoid opening symlinks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ use std::hash::Hash;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::num::NonZero;
 use std::os::unix::fs::MetadataExt as _;
+use std::os::unix::fs::OpenOptionsExt as _;
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -2204,7 +2205,12 @@ async fn serve_downloading_file(
                 };
                 drop(st);
                 drop(status);
-                let file = match tokio::fs::File::open(&path_clone).await {
+                let file = match tokio::fs::File::options()
+                    .read(true)
+                    .custom_flags(nix::libc::O_NOFOLLOW)
+                    .open(&path_clone)
+                    .await
+                {
                     Ok(f) => f,
                     Err(err) => {
                         metrics::CACHE_IO_FAILURE.increment();
@@ -2236,7 +2242,12 @@ async fn serve_downloading_file(
                 meta,
             } => {
                 // Cannot use mmap(2) since the file is not yet completely written
-                let file = match tokio::fs::File::open(&path).await {
+                let file = match tokio::fs::File::options()
+                    .read(true)
+                    .custom_flags(nix::libc::O_NOFOLLOW)
+                    .open(&path)
+                    .await
+                {
                     Ok(f) => f,
                     Err(err) => {
                         metrics::CACHE_IO_FAILURE.increment();
@@ -3375,7 +3386,12 @@ pub(crate) async fn process_cache_request(
         p
     };
 
-    match tokio::fs::File::open(&cache_path).await {
+    match tokio::fs::File::options()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(&cache_path)
+        .await
+    {
         Ok(file) => {
             // CACHE_HITS only counts permanent-file hits; volatile hits live
             // in VOLATILE_HIT / VOLATILE_REFETCHED.
@@ -4648,9 +4664,10 @@ struct ReopenableLogFile {
 
 impl ReopenableLogFile {
     fn new(path: &Path) -> std::io::Result<Self> {
-        let file = std::fs::OpenOptions::new()
+        let file = std::fs::File::options()
             .append(true)
             .create(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
             .open(path)?;
         Ok(Self {
             path: path.to_path_buf(),
@@ -4659,9 +4676,10 @@ impl ReopenableLogFile {
     }
 
     fn reopen(&self) -> std::io::Result<()> {
-        let file = std::fs::OpenOptions::new()
+        let file = std::fs::File::options()
             .append(true)
             .create(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
             .open(&self.path)?;
         *self.file.lock() = file;
         Ok(())
@@ -4783,6 +4801,13 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             )]
             let log_file_handle = match ReopenableLogFile::new(path) {
                 Ok(file) => file,
+                Err(err) if err.kind() == std::io::ErrorKind::TooManyLinks => {
+                    eprintln!(
+                        "Failed to open log file `{}`:  {err}; symlinks are not supported",
+                        path.display()
+                    );
+                    std::process::exit(1);
+                }
                 Err(err) => {
                     eprintln!("Failed to open log file `{}`:  {err}", path.display());
                     std::process::exit(1);

--- a/src/sendfile_conn.rs
+++ b/src/sendfile_conn.rs
@@ -742,7 +742,12 @@ async fn try_sendfile_request(
     // Try to open the cached file; for volatile resources, treat stale files as cache misses.
     let mut cache_miss_was_volatile_notfound = false;
     let cached_file = 'cache_lookup: {
-        let file = match tokio::fs::File::open(&cache_path).await {
+        let file = match tokio::fs::File::options()
+            .read(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
+            .open(&cache_path)
+            .await
+        {
             Ok(f) => f,
             Err(err) if err.kind() == ErrorKind::NotFound => {
                 if conn_details.cached_flavor == CachedFlavor::Volatile {
@@ -1780,7 +1785,12 @@ async fn serve_unfinished_sendfile(
                     rx,
                     meta,
                 } => {
-                    let file = match tokio::fs::File::open(path).await {
+                    let file = match tokio::fs::File::options()
+                        .read(true)
+                        .custom_flags(nix::libc::O_NOFOLLOW)
+                        .open(path)
+                        .await
+                    {
                         Ok(f) => f,
                         Err(err) => {
                             metrics::CACHE_IO_FAILURE.increment();
@@ -1810,7 +1820,12 @@ async fn serve_unfinished_sendfile(
                     let prefetched = meta.clone();
                     drop(st);
 
-                    let file = match tokio::fs::File::open(&finished_path).await {
+                    let file = match tokio::fs::File::options()
+                        .read(true)
+                        .custom_flags(nix::libc::O_NOFOLLOW)
+                        .open(&finished_path)
+                        .await
+                    {
                         Ok(f) => f,
                         Err(err) => {
                             metrics::CACHE_IO_FAILURE.increment();

--- a/src/splice_conn.rs
+++ b/src/splice_conn.rs
@@ -2482,7 +2482,12 @@ async fn serve_remaining_from_file(
     receiver: tokio::sync::watch::Receiver<()>,
     status: Arc<tokio::sync::RwLock<ActiveDownloadStatus>>,
 ) -> DeliveryResult {
-    let file = match tokio::fs::File::open(&cache_path).await {
+    let file = match tokio::fs::File::options()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(&cache_path)
+        .await
+    {
         Ok(f) => f,
         Err(err) => {
             metrics::CACHE_IO_FAILURE.increment();
@@ -3686,7 +3691,11 @@ async fn splice_proxy_drive(
         let cache_path = conn_details
             .cache_dir_path()
             .join(Path::new(&conn_details.debname));
-        if let Ok(file) = tokio::fs::File::open(&cache_path).await
+        if let Ok(file) = tokio::fs::File::options()
+            .read(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
+            .open(&cache_path)
+            .await
             && let Ok(metadata) = file.metadata().await
         {
             // Use mtime (last revalidated time), matching the hyper backend.
@@ -3789,7 +3798,12 @@ async fn splice_proxy_drive(
             metrics::record_upstream_status(response.status_code);
             metrics::VOLATILE_REFETCHED_UPTODATE.increment();
 
-            let file = match tokio::fs::File::open(&cache_path).await {
+            let file = match tokio::fs::File::options()
+                .read(true)
+                .custom_flags(nix::libc::O_NOFOLLOW)
+                .open(&cache_path)
+                .await
+            {
                 Ok(f) => f,
                 Err(err) => {
                     metrics::CACHE_IO_FAILURE.increment();
@@ -4001,7 +4015,12 @@ async fn splice_proxy_drive(
         }
         drop(upstream);
 
-        let file = match tokio::fs::File::open(&cache_path).await {
+        let file = match tokio::fs::File::options()
+            .read(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
+            .open(&cache_path)
+            .await
+        {
             Ok(f) => f,
             Err(err) => {
                 metrics::CACHE_IO_FAILURE.increment();
@@ -4692,7 +4711,10 @@ async fn splice_proxy_drive(
         let send_start = client_range_start.min(resume_offset);
         let send_end = client_range_end.min(resume_offset);
         if send_end > send_start {
-            let partial_reader = tokio::fs::File::open(temppath.as_ref())
+            let partial_reader = tokio::fs::File::options()
+                .read(true)
+                .custom_flags(nix::libc::O_NOFOLLOW)
+                .open(temppath.as_ref())
                 .await
                 .map_err(|err| {
                     metrics::CACHE_IO_FAILURE.increment();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -264,6 +264,7 @@ pub(crate) async fn open_partial_file(
         let mut file = tokio::fs::File::options()
             .write(true)
             .read(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
             .open(path)
             .await?;
 
@@ -324,6 +325,7 @@ pub(crate) async fn create_partial_file(
             .write(true)
             .read(true)
             .mode(mode)
+            .custom_flags(nix::libc::O_NOFOLLOW)
             .open(path)
             .await
     }


### PR DESCRIPTION
Symlinks are not created or used by the daemon, so do not follow any.