### PR TITLE
content-type mismatch: unify check across hyper and splice paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,25 @@ pub(crate) const VOLATILE_CACHE_MAX_AGE: Duration = Duration::from_secs(30);
 /// Maximum time to wait for the database task to drain on shutdown before giving up.
 const DB_DRAIN_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Warn (once) if the upstream `Content-Type` differs from the type derived
+/// from the cached file's basename. The non-standard `binary/octet-stream`
+/// is widely advertised by Debian mirrors and is treated as a no-op rather
+/// than a mismatch to keep the log quiet.
+pub(crate) fn warn_on_content_type_mismatch(upstream: Option<&str>, debname: &str) {
+    let Some(upstream_ct) = upstream else {
+        return;
+    };
+    if upstream_ct.eq_ignore_ascii_case("binary/octet-stream") {
+        return;
+    }
+    let expected = content_type_for_cached_file(debname);
+    if !upstream_ct.eq_ignore_ascii_case(expected) {
+        warn_once_or_info!(
+            "Upstream Content-Type `{upstream_ct}` differs from expected `{expected}` for {debname}"
+        );
+    }
+}
+
 /// Derive the Content-Type for a cached file based on its filename extension.
 #[must_use]
 pub(crate) fn content_type_for_cached_file(filename: &str) -> &'static str {
@@ -3101,12 +3120,7 @@ async fn serve_new_file(
         .headers()
         .get(CONTENT_TYPE)
         .and_then(|hv| hv.to_str().ok());
-    if let Some(ct) = upstream_content_type {
-        let expected = content_type_for_cached_file(&conn_details.debname);
-        if ct != expected {
-            warn_once_or_info!("Content-Type mismatch: expected {expected}, got {ct}");
-        }
-    }
+    warn_on_content_type_mismatch(upstream_content_type, &conn_details.debname);
 
     let (_parts, body) = fwd_response.into_parts();
 

--- a/src/splice_conn.rs
+++ b/src/splice_conn.rs
@@ -67,7 +67,7 @@ use crate::{
     OriginateOutcome, SCHEME_CACHE, Scheme, SchemeKey, SchemeKeyRef,
     VOLATILE_UNKNOWN_CONTENT_LENGTH_UPPER, cache_metadata, client_counter,
     content_type_for_cached_file, global_cache_quota, global_config, is_host_allowed_cached,
-    metrics, static_assert, warn_once_or_debug, warn_once_or_info,
+    metrics, static_assert, warn_on_content_type_mismatch, warn_once_or_debug, warn_once_or_info,
 };
 #[cfg(feature = "ktls")]
 use crate::{KTLS_BLOCKED, warn_once};
@@ -4721,14 +4721,7 @@ async fn splice_proxy_drive(
     // Write response headers to client
     let last_modified_str = upstream_resp.last_modified.as_deref();
     let content_type = content_type_for_cached_file(&conn_details.debname);
-    if let Some(upstream_ct) = upstream_resp.content_type.as_deref()
-        && !upstream_ct.eq_ignore_ascii_case(content_type)
-    {
-        warn!(
-            "splice proxy: upstream Content-Type `{upstream_ct}` differs from expected `{content_type}` for {}",
-            conn_details.debname
-        );
-    }
+    warn_on_content_type_mismatch(upstream_resp.content_type.as_deref(), &conn_details.debname);
     let date = format_http_date();
     // Fresh response streamed straight from origin → Age is 0 per RFC 9111 §4.2.3.
     let age: u32 = 0;
@@ -5578,14 +5571,7 @@ async fn handle_volatile_buffered_download(
     // Send response headers to client.
     let last_modified_str = upstream_resp.last_modified.as_deref().unwrap_or("");
     let content_type = content_type_for_cached_file(&conn_details.debname);
-    if let Some(upstream_ct) = upstream_resp.content_type.as_deref()
-        && !upstream_ct.eq_ignore_ascii_case(content_type)
-    {
-        warn!(
-            "splice proxy: upstream Content-Type `{upstream_ct}` differs from expected `{content_type}` for {}",
-            conn_details.debname
-        );
-    }
+    warn_on_content_type_mismatch(upstream_resp.content_type.as_deref(), &conn_details.debname);
     let date = format_http_date();
     // Fresh response streamed straight from origin → Age is 0 per RFC 9111 §4.2.3.
     let age: u32 = 0;


### PR DESCRIPTION
Extract the upstream-vs-expected Content-Type comparison into a single `warn_on_content_type_mismatch` helper. Replaces the inconsistent inline checks: hyper's `warn_once_or_info!` and splice's unconditional `warn!` (two sites) now share one message format and one warn-once policy. The helper also silently ignores upstream values of `binary/octet-stream`, which many Debian mirrors advertise instead of the standard `application/octet-stream`.