### PR TITLE
request_dispatch: extract shared URI dispatch from main.rs and sendfi…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ mod log_once;
 mod logstore;
 mod metrics;
 mod rate_checked_body;
+mod request_dispatch;
 mod ringbuffer;
 #[cfg(feature = "ktls")]
 mod secure_vec;
@@ -154,11 +155,9 @@ use crate::cache_layout::{CachedFlavor, ConnectionDetails, SUBDIR_TMP};
 use crate::cache_metadata::UpstreamMetadata;
 use crate::cache_metadata::UpstreamMetadataView;
 use crate::cache_quota::QuotaExceeded;
-use crate::config::CacheHost;
 use crate::config::Config;
 use crate::config::HttpsUpgradeMode;
 use crate::config::LogDestination;
-use crate::config::resolve_alias;
 use crate::database::Database;
 use crate::database_task::DatabaseCommand;
 use crate::database_task::DbCmdDelivery;
@@ -166,10 +165,7 @@ use crate::database_task::DbCmdDownload;
 use crate::database_task::DbCmdOrigin;
 use crate::database_task::db_loop;
 use crate::database_task::send_db_command;
-use crate::deb_mirror::Mirror;
 use crate::deb_mirror::Origin;
-use crate::deb_mirror::is_diff_request_path;
-use crate::deb_mirror::parse_request_path;
 use crate::error::ErrorReport;
 use crate::error::ProxyCacheError;
 use crate::guards::DownloadBarrier;
@@ -185,6 +181,7 @@ use crate::logstore::LogStore;
 use crate::permitted_host_cache::authorize_cache_access;
 use crate::permitted_host_cache::is_host_allowed_cached;
 use crate::rate_checked_body::RateCheckDirection;
+use crate::request_dispatch::{DispatchOutcome, dispatch_request};
 use crate::task_cache_scan::task_cache_scan;
 use crate::task_cleanup::{
     CLEANUP_INTERVAL_SECS, FIRST_CLEANUP_DELAY_SECS, set_next_cleanup_epoch, task_cleanup,
@@ -3930,8 +3927,6 @@ async fn pre_process_client_request(
         Err((status, msg)) => return quick_response(status, msg),
     };
 
-    let aliased_host = resolve_alias(&config.aliases, &requested_host);
-
     if req.body().size_hint().exact() != Some(0) {
         warn_once_or_info!(
             "Request from client {client} has non empty body, not forwarding body: {req:?}"
@@ -3940,114 +3935,38 @@ async fn pre_process_client_request(
     let (parts, _body) = req.into_parts();
     let req = Request::from_parts(parts, Empty::new());
 
-    let requested_path = req.uri().path();
-
-    trace!(
-        "Requested host: `{requested_host}`; Aliased host: `{aliased_host:?}`; Requested path: `{requested_path}`"
-    );
-
-    // Collapse `//` runs before parsing — clients with a trailing slash in
-    // their `sources.list` URI emit `/debian//dists/...`; raw
-    // `requested_path` is kept for logging and uncached upstream proxying.
-    let normalized_path = deb_mirror::normalize_uri_path(requested_path);
-    if let Some(resource) = parse_request_path(&normalized_path) {
-        match cache_layout::classify_request(&resource, &client) {
-            Ok(class) => {
-                // Per-host flat collision: if a structured mirror with
-                // `mirror_path == "flat"` (or `"flat/..."`) was registered
-                // on this host, the host-level `flat/` anchor is already
-                // claimed by structured caching.  Reject flat URLs on
-                // that host and fall through to the simple-proxy
-                // passthrough.
-                let cache_id: &CacheHost = match aliased_host {
-                    Some(cache) => cache,
-                    None => requested_host.as_cache_host(),
+    let requested_host =
+        match dispatch_request(req.uri().path(), requested_host, requested_port, &client).await {
+            DispatchOutcome::Cache(plan) => {
+                let conn_details = ConnectionDetails {
+                    client,
+                    mirror: plan.mirror,
+                    aliased_host: plan.aliased_host,
+                    debname: plan.debname,
+                    cached_flavor: plan.cached_flavor,
+                    layout: plan.layout,
                 };
-                if class.layout.is_flat() && flat_blocklist::is_blocked(cache_id, requested_port) {
-                    warn_once_or_info!(
-                        "Flat caching disabled for host `{requested_host}` due to colliding structured mirror; passing `{requested_path}` through uncached"
-                    );
-                } else {
-                    let mirror = Mirror::new(
-                        requested_host,
-                        requested_port,
-                        class.mirror_path,
-                        class.layout.mirror_kind(),
-                    );
-                    let conn_details = ConnectionDetails {
-                        client,
-                        mirror,
-                        aliased_host,
-                        debname: class.debname,
-                        cached_flavor: class.cached_flavor,
-                        layout: class.layout,
-                    };
-
-                    if let Some(fields) = class.origin_fields {
-                        let origin = Origin {
-                            mirror: conn_details.mirror.clone(),
-                            distribution: fields.distribution,
-                            component: fields.component,
-                            architecture: fields.architecture,
-                        };
-                        let cmd = DatabaseCommand::Origin(DbCmdOrigin { origin });
-                        send_db_command(cmd).await;
-                    }
-
-                    return process_cache_request(conn_details, req, appstate).await;
-                }
+                return process_cache_request(conn_details, req, appstate).await;
             }
-            Err(cache_layout::ClassifyError::BadEncoding { kind, raw, source }) => {
-                warn_once_or_info!(
-                    "Failed to decode {kind} `{}`:  {source}",
-                    raw.escape_debug()
-                );
-                return quick_response(StatusCode::BAD_REQUEST, "Unsupported URL encoding");
+            DispatchOutcome::Reject(reason) => {
+                let (status, msg) = reason.response_parts();
+                return quick_response(status, msg);
             }
-            Err(cache_layout::ClassifyError::InvalidValue { kind, decoded }) => {
-                warn_once_or_info!("Unsupported {kind} `{decoded}`");
-                return quick_response(StatusCode::BAD_REQUEST, "Unsupported request");
-            }
-            Err(cache_layout::ClassifyError::NonDebPool { filename }) => {
-                // Either a structured Pool filename without a
-                // `.deb`/`.udeb`/`.ddeb` extension, or a Flat::Pool
-                // filename whose decoded form failed the strict
-                // `<name>_<ver>_<arch>.<ext>` shape check.  Log and fall
-                // through to the simple proxy below (no caching).
-                warn_once_or_info!("Unsupported pool filename `{filename}` from client {client}");
-            }
-        }
-    }
+            DispatchOutcome::Passthrough { requested_host, .. } => requested_host,
+        };
 
     assert_eq!(req.method(), Method::GET, "Filtered at function start");
-
-    if global_config().reject_pdiff_requests && is_diff_request_path(requested_path) {
-        info!("Rejecting diff request {requested_path} for client {client}");
-
-        metrics::PDIFF_REJECTED.increment();
-        return quick_response(StatusCode::GONE, "Diff requests are not supported");
-    }
 
     //
     // Simple proxy (without any caching)
     //
-
-    // Reject paths with traversal sequences, control characters, or invalid encoding.
-    if deb_mirror::is_unsafe_proxy_path(requested_path) {
-        warn_once_or_info!(
-            "Rejecting unsafe unrecognized path {} for client {client}",
-            req.uri()
-        );
-        metrics::UNSAFE_PATH_REJECTED.increment();
-        return quick_response(StatusCode::BAD_REQUEST, "Unsupported request");
-    }
 
     warn_once_or_info!(
         "Proxying (without caching) request {} for client {client}",
         req.uri()
     );
 
-    record_uncacheable(&requested_host, requested_path);
+    record_uncacheable(&requested_host, req.uri().path());
 
     let (mut parts, _body) = req.into_parts();
     parts

--- a/src/request_dispatch.rs
+++ b/src/request_dispatch.rs
@@ -1,0 +1,571 @@
+//! Unified URI dispatch entry point shared by the hyper backend in
+//! `main.rs` and the sendfile backend in `sendfile_conn.rs`.
+//!
+//! Owns the request-classification pipeline that previously appeared inline
+//! in both dispatchers:
+//!
+//!   1. [`normalize_uri_path`]     - collapse `//` runs / strip `.` segments
+//!   2. [`parse_request_path`]     - structural shape-match into `ResourceFile`
+//!   3. [`classify_request`]       - per-field URL-decode + allowlist validate
+//!   4. flat-blocklist collision   - host-level `flat/` claimed by structured
+//!   5. deferred `Origin` DB write - for `Packages` requests w/ a real arch
+//!   6. diff-request reject (410)  - for parser-rejected URLs, when configured
+//!   7. unsafe-proxy-path gate     - traversal/control bytes in passthrough
+//!
+//! Backends translate the returned [`DispatchOutcome`] into their response
+//! type.  All logging, metric bumping, and deferred `Origin` DB writes happen
+//! here, so the two parallel paths cannot drift apart.  `record_uncacheable`
+//! is *not* called here - it is intentionally deferred to each backend's
+//! terminal passthrough step (hyper's simple-proxy block; the sendfile splice
+//! path).  Sendfile's `NotApplicable` handoff causes hyper to re-enter this
+//! dispatcher for the same request, so recording inside the dispatcher would
+//! double-count; recording at the terminal step yields exactly-once
+//! semantics.
+//!
+//! [`classify_request`]: crate::cache_layout::classify_request
+//! [`normalize_uri_path`]: crate::deb_mirror::normalize_uri_path
+//! [`parse_request_path`]: crate::deb_mirror::parse_request_path
+
+use std::num::NonZero;
+
+use http::StatusCode;
+use log::{info, trace};
+
+use crate::{
+    ClientInfo,
+    cache_layout::{self, CacheLayout, CachedFlavor, ClassifyError},
+    config::{Alias, CacheHost, ClientHost, resolve_alias},
+    database_task::{DatabaseCommand, DbCmdOrigin, send_db_command},
+    deb_mirror::{
+        Mirror, Origin, is_diff_request_path, is_unsafe_proxy_path, normalize_uri_path,
+        parse_request_path,
+    },
+    flat_blocklist, global_config, metrics, warn_once_or_debug, warn_once_or_info,
+};
+
+/// Post-classification payload routed through the cache pipeline.
+///
+/// Mirrors the fields of [`crate::cache_layout::ConnectionDetails`] minus
+/// `client`, which the caller adds when assembling `ConnectionDetails`.
+#[derive(Debug)]
+pub(crate) struct CachePlan {
+    pub(crate) mirror: Mirror,
+    pub(crate) aliased_host: Option<&'static CacheHost>,
+    pub(crate) debname: String,
+    pub(crate) cached_flavor: CachedFlavor,
+    pub(crate) layout: CacheLayout,
+    _private: (),
+}
+
+/// Reason the dispatcher refused a request with a fixed 4xx/5xx response.
+///
+/// Backends call [`Self::response_parts`] to materialise the `(status, body)`
+/// pair; logging and metric bumping have already been done by the dispatcher.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum RejectReason {
+    /// URL-decoding a request field produced invalid UTF-8.
+    BadEncoding,
+    /// A decoded field failed its allowlist validator
+    /// (`valid_mirrorname`, `valid_distribution`, etc.).
+    InvalidValue,
+    /// The simple-proxy gate found `..`/`.` traversal segments or a
+    /// control byte in the percent-decoded path.
+    UnsafePath,
+    /// Configured to refuse pdiff requests, and this is one
+    /// (`/Packages.diff/T-...`, `/Sources.diff/T-...`,
+    /// `/Translation-XX.diff/T-...`).
+    DiffRequest,
+}
+
+impl RejectReason {
+    /// Fixed `(status, body)` pair associated with this reason.
+    #[must_use]
+    pub(crate) const fn response_parts(self) -> (StatusCode, &'static str) {
+        match self {
+            Self::BadEncoding => (StatusCode::BAD_REQUEST, "Unsupported URL encoding"),
+            Self::InvalidValue | Self::UnsafePath => {
+                (StatusCode::BAD_REQUEST, "Unsupported request")
+            }
+            Self::DiffRequest => (StatusCode::GONE, "Diff requests are not supported"),
+        }
+    }
+}
+
+/// Why the cache pipeline declined and the request must be forwarded
+/// uncached.  Backends use this to pick between hyper's simple proxy,
+/// `splice_simple_proxy`, and the `NotApplicable` handoff back to hyper.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PassthroughReason {
+    /// The parser did not recognise a known archive shape.
+    Unrecognized,
+    /// The parser matched a Pool URL but the filename failed the
+    /// `.deb`/`.udeb`/`.ddeb` extension check or the strict flat-pool
+    /// `<name>_<ver>_<arch>.<ext>` shape check.
+    NonDebPool,
+    /// A structured mirror has registered `mirror_path == "flat"` (or
+    /// `"flat/..."`) on this host, claiming the host-level `flat/`
+    /// anchor.  Flat caching is disabled for the host
+    /// (see [`crate::flat_blocklist`]).
+    FlatBlocked,
+}
+
+/// Dispatcher verdict.  Backends own response-type construction; this
+/// module owns logging, metric bumping, and deferred `Origin` DB writes, so
+/// the two backends stay structurally in sync.  `record_uncacheable` is
+/// *not* called here - see the module docs for why it is deferred to each
+/// backend's terminal forwarding step.
+#[derive(Debug)]
+pub(crate) enum DispatchOutcome {
+    /// Route through the cache pipeline using `plan` as the
+    /// `ConnectionDetails` seed.
+    Cache(CachePlan),
+    /// Refuse with a fixed 4xx/5xx response.  Logging and metric bumping
+    /// already done.
+    Reject(RejectReason),
+    /// Forward to upstream uncached.  Logging and metric bumping already
+    /// done; the caller is responsible for `record_uncacheable` at its
+    /// terminal forwarding step.  `requested_host` is returned so backends
+    /// can build an upstream `Mirror` or emit per-request log lines without
+    /// re-deriving it.
+    Passthrough {
+        // The hyper backend (`main.rs`) only needs `requested_host` to
+        // continue its uncached forwarding flow; the sendfile backend
+        // (`sendfile_conn.rs`) inspects `reason` to choose between
+        // `splice_simple_proxy` and a `NotApplicable` handoff back to
+        // hyper.  Under feature configurations that exclude sendfile
+        // (e.g. `--no-default-features --features tls_hyper`), the field
+        // is genuinely unread in non-test builds - silence the dead-code
+        // lint there only (tests pattern-match on it directly).
+        #[cfg_attr(
+            all(not(feature = "sendfile"), not(test)),
+            expect(dead_code, reason = "consumed only by sendfile_conn dispatch")
+        )]
+        reason: PassthroughReason,
+        requested_host: ClientHost,
+    },
+}
+
+/// Output of [`decide_request`].
+///
+/// Carries the synchronous [`DispatchOutcome`] plus any deferred side-effect
+/// the async wrapper must drive.  The split lets unit tests exercise the
+/// routing logic without standing up the DB task channel.
+#[derive(Debug)]
+struct Decision {
+    outcome: DispatchOutcome,
+    /// `Some` only on a `Cache` outcome whose `class.origin_fields` indicated
+    /// a real (non-pseudo) architecture; the wrapper forwards the value to
+    /// `send_db_command` before returning the outcome.
+    pending_origin: Option<Origin>,
+}
+
+/// Classify an incoming request URL and decide how to route it.
+///
+/// `uri_path` is the **raw** request-line path (not yet normalised); the
+/// dispatcher normalises internally for parsing while keeping the raw form
+/// for logs and the simple-proxy passthrough.  `client` is borrowed for log
+/// inclusion only; nothing about the classification depends on caller
+/// identity.
+pub(crate) async fn dispatch_request(
+    uri_path: &str,
+    requested_host: ClientHost,
+    requested_port: Option<NonZero<u16>>,
+    client: &ClientInfo,
+) -> DispatchOutcome {
+    let cfg = global_config();
+    let decision = decide_request(
+        uri_path,
+        requested_host,
+        requested_port,
+        client,
+        &cfg.aliases,
+        cfg.reject_pdiff_requests,
+        flat_blocklist::is_blocked,
+    );
+    if let Some(origin) = decision.pending_origin {
+        send_db_command(DatabaseCommand::Origin(DbCmdOrigin { origin })).await;
+    }
+    decision.outcome
+}
+
+/// Pure routing decision: no global reads, no async side-effects.
+///
+/// The two real-world side-effects that surround it -
+/// `flat_blocklist::is_blocked` and the deferred `Origin` DB write - are
+/// expressed as a closure and a return-value field respectively, so unit
+/// tests can drive every branch without standing up the DB task channel or
+/// the `RUNTIMEDETAILS`/`BLOCKLIST` `OnceLock`s.
+fn decide_request(
+    uri_path: &str,
+    requested_host: ClientHost,
+    requested_port: Option<NonZero<u16>>,
+    client: &ClientInfo,
+    aliases: &'static [Alias],
+    reject_pdiff_requests: bool,
+    is_flat_blocked: impl FnOnce(&CacheHost, Option<NonZero<u16>>) -> bool,
+) -> Decision {
+    trace!("Dispatching request from client {client}: host=`{requested_host}` path=`{uri_path}`");
+
+    let normalized = normalize_uri_path(uri_path);
+    let passthrough_reason: PassthroughReason = match parse_request_path(&normalized) {
+        None => {
+            warn_once_or_debug!("Unrecognized resource path from client {client}: {uri_path}");
+            PassthroughReason::Unrecognized
+        }
+        Some(resource) => match cache_layout::classify_request(&resource, client) {
+            Ok(class) => {
+                let aliased_host = resolve_alias(aliases, &requested_host);
+
+                let cache_id: &CacheHost = match aliased_host {
+                    Some(cache) => cache,
+                    None => requested_host.as_cache_host(),
+                };
+                if class.layout.is_flat() && is_flat_blocked(cache_id, requested_port) {
+                    warn_once_or_info!(
+                        "Flat caching disabled for host `{requested_host}` due to colliding structured mirror; passing `{uri_path}` through uncached for client {client}"
+                    );
+                    PassthroughReason::FlatBlocked
+                } else {
+                    let mirror = Mirror::new(
+                        requested_host,
+                        requested_port,
+                        class.mirror_path,
+                        class.layout.mirror_kind(),
+                    );
+
+                    let pending_origin = class.origin_fields.map(|fields| Origin {
+                        mirror: mirror.clone(),
+                        distribution: fields.distribution,
+                        component: fields.component,
+                        architecture: fields.architecture,
+                    });
+
+                    return Decision {
+                        outcome: DispatchOutcome::Cache(CachePlan {
+                            mirror,
+                            aliased_host,
+                            debname: class.debname,
+                            cached_flavor: class.cached_flavor,
+                            layout: class.layout,
+                            _private: (),
+                        }),
+                        pending_origin,
+                    };
+                }
+            }
+            Err(ClassifyError::BadEncoding { kind, raw, source }) => {
+                warn_once_or_info!(
+                    "Failed to decode {kind} `{}` from client {client}:  {source}",
+                    raw.escape_debug()
+                );
+                return Decision {
+                    outcome: DispatchOutcome::Reject(RejectReason::BadEncoding),
+                    pending_origin: None,
+                };
+            }
+            Err(ClassifyError::InvalidValue { kind, decoded }) => {
+                warn_once_or_info!("Unsupported {kind} `{decoded}` from client {client}");
+                return Decision {
+                    outcome: DispatchOutcome::Reject(RejectReason::InvalidValue),
+                    pending_origin: None,
+                };
+            }
+            Err(ClassifyError::NonDebPool { filename }) => {
+                warn_once_or_info!("Unsupported pool filename `{filename}` from client {client}");
+                PassthroughReason::NonDebPool
+            }
+        },
+    };
+
+    // The cache pipeline declined.  Before forwarding upstream uncached,
+    // run the two gates that apply to all passthrough requests: refuse
+    // pdiff (if configured) and refuse traversal/control-byte paths.
+
+    if reject_pdiff_requests && is_diff_request_path(uri_path) {
+        info!("Rejecting diff request {uri_path} for client {client}");
+        metrics::PDIFF_REJECTED.increment();
+        return Decision {
+            outcome: DispatchOutcome::Reject(RejectReason::DiffRequest),
+            pending_origin: None,
+        };
+    }
+
+    if is_unsafe_proxy_path(uri_path) {
+        let passthrough_label = match passthrough_reason {
+            PassthroughReason::Unrecognized => "unrecognized",
+            PassthroughReason::NonDebPool => "non-deb pool",
+            PassthroughReason::FlatBlocked => "flat-blocked",
+        };
+        warn_once_or_info!(
+            "Rejecting unsafe passthrough path {uri_path} ({passthrough_label}) for client {client}"
+        );
+        metrics::UNSAFE_PATH_REJECTED.increment();
+        return Decision {
+            outcome: DispatchOutcome::Reject(RejectReason::UnsafePath),
+            pending_origin: None,
+        };
+    }
+
+    // `record_uncacheable` is intentionally NOT called here.  The sendfile
+    // backend hands `NonDebPool` / `FlatBlocked` / non-splice `Unrecognized`
+    // back to hyper via `ZeroCopyResult::NotApplicable`, which causes hyper
+    // to re-enter this dispatcher for the same request.  Recording at the
+    // backend's terminal forwarding step (hyper's simple-proxy block; the
+    // sendfile splice path) instead of inside the dispatcher gives an
+    // exactly-once guarantee.
+    Decision {
+        outcome: DispatchOutcome::Passthrough {
+            reason: passthrough_reason,
+            requested_host,
+        },
+        pending_origin: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+    use super::*;
+    use crate::ClientInfo;
+
+    fn fake_client() -> ClientInfo {
+        ClientInfo::new(SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))
+    }
+
+    fn fake_host() -> ClientHost {
+        ClientHost::new("deb.example.com".to_string()).unwrap()
+    }
+
+    fn never_flat_blocked(_: &CacheHost, _: Option<NonZero<u16>>) -> bool {
+        false
+    }
+
+    #[test]
+    fn cache_outcome_for_pool_deb() {
+        let decision = decide_request(
+            "/debian/pool/main/f/firefox/firefox_1.0_amd64.deb",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            never_flat_blocked,
+        );
+        let DispatchOutcome::Cache(plan) = decision.outcome else {
+            unreachable!("expected Cache outcome")
+        };
+        assert_eq!(plan.layout, CacheLayout::StructuredPool);
+        assert_eq!(plan.debname, "firefox_1.0_amd64.deb");
+        assert!(decision.pending_origin.is_none());
+    }
+
+    #[test]
+    fn cache_outcome_packages_with_real_arch_records_origin() {
+        let decision = decide_request(
+            "/debian/dists/sid/main/binary-amd64/Packages.gz",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            never_flat_blocked,
+        );
+        let DispatchOutcome::Cache(plan) = decision.outcome else {
+            unreachable!("expected Cache outcome")
+        };
+        assert_eq!(plan.layout, CacheLayout::Dists);
+        let origin = decision
+            .pending_origin
+            .expect("binary-amd64 must record an origin");
+        assert_eq!(origin.distribution, "sid");
+        assert_eq!(origin.component, "main");
+        assert_eq!(origin.architecture, "binary-amd64");
+    }
+
+    #[test]
+    fn passthrough_unrecognized_when_parser_declines() {
+        let decision = decide_request(
+            "/foo/bar.txt",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            never_flat_blocked,
+        );
+        assert!(
+            matches!(
+                decision.outcome,
+                DispatchOutcome::Passthrough {
+                    reason: PassthroughReason::Unrecognized,
+                    ..
+                }
+            ),
+            "expected Unrecognized passthrough, got {:?}",
+            decision.outcome
+        );
+        assert!(decision.pending_origin.is_none());
+    }
+
+    #[test]
+    fn passthrough_non_deb_pool_for_pool_with_text_filename() {
+        let decision = decide_request(
+            "/debian/pool/main/f/foo/README.txt",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            never_flat_blocked,
+        );
+        assert!(
+            matches!(
+                decision.outcome,
+                DispatchOutcome::Passthrough {
+                    reason: PassthroughReason::NonDebPool,
+                    ..
+                }
+            ),
+            "expected NonDebPool passthrough, got {:?}",
+            decision.outcome
+        );
+        assert!(decision.pending_origin.is_none());
+    }
+
+    #[test]
+    fn passthrough_flat_blocked_when_blocklist_hits() {
+        let decision = decide_request(
+            "/apt/Packages.gz",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            |_, _| true,
+        );
+        assert!(
+            matches!(
+                decision.outcome,
+                DispatchOutcome::Passthrough {
+                    reason: PassthroughReason::FlatBlocked,
+                    ..
+                }
+            ),
+            "expected FlatBlocked passthrough, got {:?}",
+            decision.outcome
+        );
+        assert!(decision.pending_origin.is_none());
+    }
+
+    #[test]
+    fn flat_request_caches_when_blocklist_does_not_hit() {
+        let decision = decide_request(
+            "/apt/Packages.gz",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            never_flat_blocked,
+        );
+        assert!(
+            matches!(decision.outcome, DispatchOutcome::Cache(_)),
+            "expected Cache, got {:?}",
+            decision.outcome
+        );
+    }
+
+    #[test]
+    fn reject_pdiff_request_when_configured() {
+        let decision = decide_request(
+            "/debian/dists/sid/main/binary-amd64/Packages.diff/T-12345",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            never_flat_blocked,
+        );
+        assert!(
+            matches!(
+                decision.outcome,
+                DispatchOutcome::Reject(RejectReason::DiffRequest)
+            ),
+            "expected DiffRequest reject, got {:?}",
+            decision.outcome
+        );
+    }
+
+    #[test]
+    fn pdiff_request_passes_through_when_not_configured() {
+        let decision = decide_request(
+            "/debian/dists/sid/main/binary-amd64/Packages.diff/T-12345",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            false,
+            never_flat_blocked,
+        );
+        // Path is not a recognised structured shape (parser rejects), and the
+        // pdiff gate is disabled, so this falls through to a plain Unrecognized
+        // passthrough.
+        assert!(
+            matches!(
+                decision.outcome,
+                DispatchOutcome::Passthrough {
+                    reason: PassthroughReason::Unrecognized,
+                    ..
+                }
+            ),
+            "expected Unrecognized passthrough, got {:?}",
+            decision.outcome
+        );
+    }
+
+    #[test]
+    fn reject_unsafe_traversal_path() {
+        let decision = decide_request(
+            "/foo/../etc/passwd",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            never_flat_blocked,
+        );
+        assert!(
+            matches!(
+                decision.outcome,
+                DispatchOutcome::Reject(RejectReason::UnsafePath)
+            ),
+            "expected UnsafePath reject, got {:?}",
+            decision.outcome
+        );
+    }
+
+    #[test]
+    fn pdiff_rejection_wins_over_unsafe_path_check() {
+        // The dispatcher runs the pdiff gate before the unsafe-path gate, so a
+        // path that triggers both is rejected as a DiffRequest.  This locks in
+        // ordering: future refactors that swap the gates will fail this test.
+        let decision = decide_request(
+            "/debian/dists/sid/main/binary-amd64/Packages.diff/T-../escape",
+            fake_host(),
+            None,
+            &fake_client(),
+            &[],
+            true,
+            never_flat_blocked,
+        );
+        assert!(
+            matches!(
+                decision.outcome,
+                DispatchOutcome::Reject(RejectReason::DiffRequest)
+            ),
+            "expected DiffRequest reject, got {:?}",
+            decision.outcome
+        );
+    }
+}

--- a/src/sendfile_conn.rs
+++ b/src/sendfile_conn.rs
@@ -17,15 +17,10 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 
 use crate::cache_conditional::CacheInfo;
-use crate::cache_layout::{self, CachedFlavor, ConnectionDetails};
+use crate::cache_layout::{CachedFlavor, ConnectionDetails};
 use crate::cache_metadata::{self, CacheMetadataKeyRef};
-use crate::config::{CacheHost, resolve_alias};
-use crate::database_task::{DatabaseCommand, DbCmdDelivery, DbCmdOrigin, send_db_command};
-use crate::deb_mirror::{
-    Mirror, Origin, is_unsafe_proxy_path, normalize_uri_path, parse_request_path,
-};
+use crate::database_task::{DatabaseCommand, DbCmdDelivery, send_db_command};
 use crate::error::{ErrorReport, errno_to_io_error};
-use crate::flat_blocklist;
 use crate::http_helpers::{
     ConnectionAction, ConnectionVersion, ResponseHeaders, WritePhase, find_header, find_header_end,
     write_304_response, write_416_response, write_all_to_stream, write_invalid_response,
@@ -34,13 +29,14 @@ use crate::http_helpers::{
 use crate::http_range::{ParsedRange, format_http_date, http_parse_range};
 use crate::humanfmt::HumanFmt;
 use crate::rate_checked_body::{InsufficientRate, RateCheckDirection, RateChecker};
+use crate::request_dispatch::{DispatchOutcome, PassthroughReason, RejectReason, dispatch_request};
 use crate::tcp_cork_guard::CorkGuard;
 use crate::utils::{hint_sequential_read, is_peer_disconnect};
 use crate::{
     APP_NAME, ActiveDownloadStatus, AppState, ClientInfo, ContentLength, Never,
     VOLATILE_CACHE_MAX_AGE, authorize_cache_access, client_counter, content_type_for_cached_file,
-    global_config, handle_hyper_connection, is_diff_request_path, metrics, static_assert,
-    warn_once_or_debug, warn_once_or_info,
+    global_config, handle_hyper_connection, metrics, static_assert, warn_once_or_debug,
+    warn_once_or_info,
     web_interface::{HTML_CSP, WebResponse, WebResponseKind, serve_web_interface},
 };
 
@@ -576,47 +572,55 @@ async fn try_sendfile_request(
 
     let conn_action = compute_conn_action(&req, *conn_version, &client);
 
-    // Match all cacheable resource types for sendfile/splice serving.
-    // Collapse `//` runs before parsing — clients with a trailing slash in
-    // their `sources.list` URI emit `/debian//dists/...`; raw `uri_path` is
-    // preserved for logs and upstream simple-proxy passthrough so the
-    // client request still flows verbatim when the parser declines it.
+    // Unified dispatch shared with main.rs: normalize -> parse -> classify
+    // -> flat-blocklist -> diff-reject -> unsafe-path gate.  Logging,
+    // metric bumping, and deferred Origin DB writes happen inside
+    // `dispatch_request`; this match only maps outcomes to ZeroCopyResult.
     let uri_path = uri.path();
-    let normalized_uri_path = normalize_uri_path(uri_path);
-    let Some(resource) = parse_request_path(&normalized_uri_path) else {
-        if global_config().reject_pdiff_requests && is_diff_request_path(uri_path) {
-            info!("Rejecting diff request {uri_path} for client {client}");
-
-            metrics::PDIFF_REJECTED.increment();
-            return ZeroCopyResult::Rejection {
-                status: StatusCode::GONE,
-                conn_action,
-                msg: "Diff requests are not supported",
+    let plan = match dispatch_request(uri_path, requested_host, requested_port, &client).await {
+        DispatchOutcome::Cache(plan) => plan,
+        DispatchOutcome::Reject(reason) => {
+            let (status, msg) = reason.response_parts();
+            // Diff-request rejections keep the connection alive; the other
+            // 4xx variants close to defend against header smuggling.
+            return match reason {
+                RejectReason::DiffRequest => ZeroCopyResult::Rejection {
+                    status,
+                    conn_action,
+                    msg,
+                },
+                RejectReason::BadEncoding
+                | RejectReason::InvalidValue
+                | RejectReason::UnsafePath => ZeroCopyResult::Invalid { status, msg },
             };
         }
-
-        warn_once_or_debug!("Unrecognized resource path from client {client}: {uri_path}");
-
-        // Reject paths with traversal sequences, control characters, or invalid encoding.
-        if is_unsafe_proxy_path(uri_path) {
-            metrics::UNSAFE_PATH_REJECTED.increment();
-            warn_once_or_info!(
-                "Rejecting unsafe unrecognized path from client {client}: {uri_path}"
-            );
-            return ZeroCopyResult::Invalid {
-                status: StatusCode::BAD_REQUEST,
-                msg: "Unsupported request",
-            };
-        }
-
+        // Pool filename failed the deb-extension or strict-flat-shape check;
+        // hand back to hyper so the simple proxy can handle it without caching.
+        DispatchOutcome::Passthrough {
+            reason: PassthroughReason::NonDebPool,
+            requested_host: _,
+        } => return ZeroCopyResult::NotApplicable("unsupported pool filename"),
+        // Structured mirror has claimed this host's `flat/` anchor; hand back
+        // to hyper which will pass the request through uncached.
+        DispatchOutcome::Passthrough {
+            reason: PassthroughReason::FlatBlocked,
+            requested_host: _,
+        } => return ZeroCopyResult::NotApplicable("flat host blocked by structured collision"),
         #[cfg(feature = "splice")]
-        {
+        DispatchOutcome::Passthrough {
+            reason: PassthroughReason::Unrecognized,
+            requested_host,
+        } => {
             use crate::{
-                deb_mirror::MirrorKind,
+                deb_mirror::{Mirror, MirrorKind},
                 splice_conn::{SpliceProxyError, splice_simple_proxy},
                 uncacheables::record_uncacheable,
             };
 
+            // Splice serves this request directly; hyper won't re-enter the
+            // dispatcher, so record here.  The `NotApplicable` arms above
+            // intentionally skip this - hyper records when it re-runs the
+            // dispatcher.
             record_uncacheable(&requested_host, uri_path);
 
             // Simple-proxy path: this Mirror is used only for upstream
@@ -675,83 +679,26 @@ async fn try_sendfile_request(
                 },
             };
         }
-
         #[cfg(not(feature = "splice"))]
-        return ZeroCopyResult::NotApplicable("unrecognized resource path");
+        DispatchOutcome::Passthrough {
+            reason: PassthroughReason::Unrecognized,
+            requested_host: _,
+        } => return ZeroCopyResult::NotApplicable("unrecognized resource path"),
     };
 
-    let class = match cache_layout::classify_request(&resource, &client) {
-        Ok(class) => class,
-        Err(cache_layout::ClassifyError::BadEncoding { kind, raw, source }) => {
-            warn_once_or_info!(
-                "Failed to decode {kind} `{}` from client {client}:  {source}",
-                raw.escape_debug()
-            );
-            return ZeroCopyResult::Invalid {
-                status: StatusCode::BAD_REQUEST,
-                msg: "Unsupported URL encoding",
-            };
-        }
-        Err(cache_layout::ClassifyError::InvalidValue { kind, decoded }) => {
-            warn_once_or_info!("Unsupported {kind} `{decoded}` from client {client}");
-            return ZeroCopyResult::Invalid {
-                status: StatusCode::BAD_REQUEST,
-                msg: "Unsupported request",
-            };
-        }
-        Err(cache_layout::ClassifyError::NonDebPool { filename: _ }) => {
-            // Pool filename failed the deb extension check (structured
-            // Pool) or the strict flat-pool shape check; hand back to
-            // hyper so the simple proxy can handle it without caching.
-            return ZeroCopyResult::NotApplicable("unsupported pool filename");
-        }
-    };
-
-    let aliased_host = resolve_alias(&global_config().aliases, &requested_host);
-
-    // Per-host flat collision: a structured mirror with
-    // `mirror_path == "flat"` (or `"flat/..."`) has already claimed the
-    // host-level `flat/` anchor; hand back to hyper which will pass the
-    // request through uncached. The blocklist is keyed on the alias-resolved
-    // host (matching the on-disk host directory) so sibling aliases share it.
-    let cache_id: &CacheHost = match aliased_host {
-        Some(cache) => cache,
-        None => requested_host.as_cache_host(),
-    };
-    if class.layout.is_flat() && flat_blocklist::is_blocked(cache_id, requested_port) {
-        return ZeroCopyResult::NotApplicable("flat host blocked by structured collision");
-    }
-
-    let aliased = match aliased_host {
+    let aliased = match plan.aliased_host {
         Some(alias) => format!(" aliased to host {alias}"),
         None => String::new(),
     };
 
     let conn_details = ConnectionDetails {
         client,
-        mirror: Mirror::new(
-            requested_host,
-            requested_port,
-            class.mirror_path,
-            class.layout.mirror_kind(),
-        ),
-        aliased_host,
-        debname: class.debname,
-        cached_flavor: class.cached_flavor,
-        layout: class.layout,
+        mirror: plan.mirror,
+        aliased_host: plan.aliased_host,
+        debname: plan.debname,
+        cached_flavor: plan.cached_flavor,
+        layout: plan.layout,
     };
-
-    // Record origin for Packages requests (mirrors main.rs behavior)
-    if let Some(fields) = class.origin_fields {
-        let origin = Origin {
-            mirror: conn_details.mirror.clone(),
-            distribution: fields.distribution,
-            component: fields.component,
-            architecture: fields.architecture,
-        };
-        let cmd = DatabaseCommand::Origin(DbCmdOrigin { origin });
-        send_db_command(cmd).await;
-    }
 
     // Check if the file is currently being downloaded — if so, serve it via
     // sendfile from the growing partial file instead of falling back to hyper.


### PR DESCRIPTION
…le_conn.rs

Both backends previously inlined the same seven-step pipeline (normalize -> parse -> classify -> flat-blocklist -> deferred-Origin-DB-write -> diff-reject -> unsafe-path gate). The new module is the single source of truth; each backend collapses to a single match on DispatchOutcome.

Behavior preserved with two minor deltas worth noting:
- Hyper path now emits warn_once_or_debug for unparseable paths (previously silent until the "Proxying (without caching)" line).
- An UnsafePath hit on a NonDebPool / FlatBlocked URL closes the connection under sendfile (Invalid) instead of keep-alive via hyper after handoff. Vanishingly rare (parser-matched URL whose decoded fields still contain ../control bytes) and arguably more defensive.

record_uncacheable is called exactly once per request: hyper's simple-proxy block records unconditionally; sendfile records only on the splice Unrecognized branch that serves the request directly. Paths that hand back to hyper via NotApplicable rely on hyper to record when it re-runs the dispatcher.

Net change in the duplicated dispatchers: +76 insertions, -210 deletions; +261 lines in the new shared module. One parallel-paths invariant retired.