### PR TITLE
overhaul rate-logging design for per-request timing

### DIFF
--- a/src/cache_layout.rs
+++ b/src/cache_layout.rs
@@ -53,6 +53,7 @@ use std::{
     string::FromUtf8Error,
 };
 
+use coarsetime::Instant;
 use log::trace;
 
 use crate::{
@@ -194,6 +195,9 @@ impl CacheLayout {
 #[derive(Clone, Debug)]
 pub(crate) struct ConnectionDetails {
     pub(crate) client: ClientInfo,
+    /// Monotonic instant the client request was parsed - origin of the
+    /// `in <time>` total-proxy-time figure in download/serve logs.
+    pub(crate) request_received_at: Instant,
     pub(crate) mirror: Mirror,
     pub(crate) aliased_host: Option<&'static CacheHost>,
     pub(crate) debname: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ mod log_once;
 mod logstore;
 mod metrics;
 mod rate_checked_body;
+mod rate_log;
 mod request_dispatch;
 mod ringbuffer;
 #[cfg(feature = "ktls")]
@@ -824,20 +825,24 @@ impl<S> PinnedDrop for DeliveryStreamBody<S> {
                 Some(alias) => format!(" aliased to host {alias}"),
                 None => String::new(),
             };
+            let in_time = cd.request_received_at.elapsed();
+            let volatile = if cd.cached_flavor == CachedFlavor::Volatile {
+                "volatile "
+            } else {
+                ""
+            };
             if transferred_bytes == size {
                 metrics::SERVED_COPY.increment();
                 metrics::SERVED_TOTAL.increment();
                 info!(
-                    "Served cached file {} from mirror {}{} for client {} in {} via stream (size={}, rate={})",
+                    "Served cached {volatile}file {} from mirror {}{} for client {} in {} via stream ({})",
                     cd.debname,
                     cd.mirror,
                     aliased,
                     cd.client,
-                    HumanFmt::Time(duration.into()),
-                    HumanFmt::Size(size),
-                    HumanFmt::Rate(size, duration)
+                    HumanFmt::Time(in_time.into()),
+                    rate_log::client_segment(size, duration),
                 );
-
                 let cmd = DatabaseCommand::Delivery(DbCmdDelivery {
                     mirror: cd.mirror,
                     debname: cd.debname,
@@ -847,28 +852,16 @@ impl<S> PinnedDrop for DeliveryStreamBody<S> {
                     client_ip: cd.client.ip(),
                 });
                 send_db_command(cmd).await;
-            } else if transferred_bytes == 0 && duration < coarsetime::Duration::from_secs(1) {
-                info!(
-                    "Aborted serving cached file {} from mirror {}{} for client {} after {} via stream:  {}",
-                    cd.debname,
-                    cd.mirror,
-                    aliased,
-                    cd.client,
-                    HumanFmt::Time(duration.into()),
-                    error.unwrap_or_else(|| String::from("unknown reason")),
-                );
             } else {
+                let segment = rate_log::client_disconnect_segment(transferred_bytes, duration);
+                let reason = error.unwrap_or_else(|| String::from("unknown reason"));
                 warn!(
-                    "Failed to serve cached file {} from mirror {}{} for client {} after {} via stream (size={}, transferred={}, rate={}):  {}",
+                    "Served cached {volatile}file {} from mirror {}{} for client {} in {} via stream ({segment}):  {reason}",
                     cd.debname,
                     cd.mirror,
                     aliased,
                     cd.client,
-                    HumanFmt::Time(duration.into()),
-                    HumanFmt::Size(size),
-                    HumanFmt::Size(transferred_bytes),
-                    HumanFmt::Rate(transferred_bytes, duration),
-                    error.unwrap_or_else(|| String::from("unknown reason")),
+                    HumanFmt::Time(in_time.into()),
                 );
             }
         });
@@ -988,19 +981,41 @@ impl bytes::buf::Buf for ProxyCacheBodyData {
 ///
 /// On Drop, bumps `SERVED_PASSTHROUGH` + `SERVED_TOTAL` iff the inner body
 /// reached clean end-of-stream (`poll_frame` returned `Ready(None)`) — so
-/// aborted clients do not increment the served counter.
+/// aborted clients do not increment the served counter.  Also logs a
+/// per-request rate summary (total in-time, upstream rate, client rate).
 #[pin_project(PinnedDrop)]
 struct PassthroughBody<B: Body> {
     #[pin]
     inner: B,
     end_of_stream: bool,
+    transferred: u64,
+    start: Instant,
+    request_received_at: Instant,
+    request_sent: Instant,
+    host: String,
+    path: String,
+    client: ClientInfo,
 }
 
 impl<B: Body> PassthroughBody<B> {
-    fn new(inner: B) -> Self {
+    fn new(
+        inner: B,
+        request_received_at: Instant,
+        request_sent: Instant,
+        host: String,
+        path: String,
+        client: ClientInfo,
+    ) -> Self {
         Self {
             inner,
             end_of_stream: false,
+            transferred: 0,
+            start: Instant::now(),
+            request_received_at,
+            request_sent,
+            host,
+            path,
+            client,
         }
     }
 }
@@ -1022,7 +1037,9 @@ where
         match &result {
             Ready(Some(Ok(frame))) => {
                 if let Some(data) = frame.data_ref() {
-                    metrics::BYTES_SERVED_PASSTHROUGH.increment_by(data.remaining() as u64);
+                    let n = data.remaining() as u64;
+                    metrics::BYTES_SERVED_PASSTHROUGH.increment_by(n);
+                    *this.transferred += n;
                 }
             }
             Ready(None) => {
@@ -1047,9 +1064,30 @@ where
 #[pinned_drop]
 impl<B: Body> PinnedDrop for PassthroughBody<B> {
     fn drop(self: Pin<&mut Self>) {
-        if self.end_of_stream {
+        let transferred = self.transferred;
+        let client_window = self.start.elapsed();
+        let in_time = self.request_received_at.elapsed();
+        let upstream_window = self.request_sent.elapsed();
+        let end_of_stream = self.end_of_stream;
+        let this = self.project();
+        let host = std::mem::take(this.host);
+        let path = std::mem::take(this.path);
+        let client = *this.client;
+        if end_of_stream {
             metrics::SERVED_PASSTHROUGH.increment();
             metrics::SERVED_TOTAL.increment();
+            info!(
+                "Simple proxy: passed through {path} from host {host} for client {client} in {} ({}, {})",
+                HumanFmt::Time(in_time.into()),
+                rate_log::upstream_segment(transferred, upstream_window),
+                rate_log::client_segment(transferred, client_window),
+            );
+        } else {
+            info!(
+                "Simple proxy: passed through {path} from host {host} for client {client} in {} ({})",
+                HumanFmt::Time(in_time.into()),
+                rate_log::client_disconnect_segment(transferred, client_window),
+            );
         }
     }
 }
@@ -1145,18 +1183,23 @@ impl Drop for MmapBody {
                 Some(alias) => format!(" aliased to host {alias}"),
                 None => String::new(),
             };
+            let in_time = cd.request_received_at.elapsed();
+            let volatile = if cd.cached_flavor == CachedFlavor::Volatile {
+                "volatile "
+            } else {
+                ""
+            };
             if transferred_bytes == size {
                 metrics::SERVED_MMAP.increment();
                 metrics::SERVED_TOTAL.increment();
                 info!(
-                    "Served cached file {} from mirror {}{} for client {} in {} via mmap (size={}, rate={})",
+                    "Served cached {volatile}file {} from mirror {}{} for client {} in {} via mmap ({})",
                     cd.debname,
                     cd.mirror,
                     aliased,
                     cd.client,
-                    HumanFmt::Time(elapsed.into()),
-                    HumanFmt::Size(size),
-                    HumanFmt::Rate(size, elapsed)
+                    HumanFmt::Time(in_time.into()),
+                    rate_log::client_segment(size, elapsed),
                 );
 
                 let cmd = DatabaseCommand::Delivery(DbCmdDelivery {
@@ -1168,26 +1211,15 @@ impl Drop for MmapBody {
                     client_ip: cd.client.ip(),
                 });
                 send_db_command(cmd).await;
-            } else if transferred_bytes == 0 {
-                info!(
-                    "Aborted serving cached file {} from mirror {}{} for client {} after {} via mmap",
-                    cd.debname,
-                    cd.mirror,
-                    aliased,
-                    cd.client,
-                    HumanFmt::Time(elapsed.into()),
-                );
             } else {
+                let segment = rate_log::client_disconnect_segment(transferred_bytes, elapsed);
                 warn!(
-                    "Failed to serve cached file {} from mirror {}{} for client {} after {} via mmap (size={}, transferred={}, rate={})",
+                    "Served cached {volatile}file {} from mirror {}{} for client {} in {} via mmap ({segment})",
                     cd.debname,
                     cd.mirror,
                     aliased,
                     cd.client,
-                    HumanFmt::Time(elapsed.into()),
-                    HumanFmt::Size(size),
-                    HumanFmt::Size(transferred_bytes),
-                    HumanFmt::Rate(transferred_bytes, elapsed),
+                    HumanFmt::Time(in_time.into()),
                 );
             }
         });
@@ -1866,6 +1898,7 @@ async fn download_file(
     output: (tokio::fs::File, TempPath),
     mut dbarrier: DownloadBarrier,
     resume_offset: u64,
+    request_sent: Instant,
 ) {
     let config = global_config();
 
@@ -1914,7 +1947,7 @@ async fn download_file(
                         }
                         metrics::UPSTREAM_HYPER_BODY_ERR.increment();
                         error!(
-                            "Error extracting frame from body for file {} from mirror {} (time={}, size={}, rate={}):  {}",
+                            "Error extracting frame from body for file {} from mirror {} (time={}, size={}, upstream_rate={}):  {}",
                             conn_details.debname,
                             conn_details.mirror,
                             HumanFmt::Time(start.elapsed().into()),
@@ -1988,6 +2021,8 @@ async fn download_file(
             }
         }
     }
+
+    let t_upstream_done = Instant::now();
 
     if let Err(err) = writer.flush().await {
         error!("Failed to write to file `{}`:  {err}", outpath.display());
@@ -2072,28 +2107,24 @@ async fn download_file(
 
     let total_bytes = resume_offset + bytes;
     let elapsed = start.elapsed();
-    // `rate` is computed over `bytes` (newly downloaded portion) against
-    // `elapsed`, which matches when not resuming. When resuming, label it
-    // `resume_rate` so the reader does not mistake it for an average over
-    // the full `size`.
-    let rate_label = if resume_offset > 0 {
-        "resume_rate"
+    let in_time = conn_details.request_received_at.elapsed();
+    let volatile = if conn_details.cached_flavor == CachedFlavor::Volatile {
+        "volatile "
     } else {
-        "rate"
+        ""
     };
     info!(
-        "Finished download of file {} from mirror {} for client {} in {} (size={}, {rate_label}={}{})",
+        "Finished download of {volatile}file {} from mirror {} for client {} in {} ({}){}",
         conn_details.debname,
         conn_details.mirror,
         conn_details.client,
-        HumanFmt::Time(elapsed.into()),
-        HumanFmt::Size(total_bytes),
-        HumanFmt::Rate(bytes, elapsed),
+        HumanFmt::Time(in_time.into()),
+        rate_log::upstream_segment(bytes, t_upstream_done.duration_since(request_sent)),
         if resume_offset > 0 {
             format!(", resumed from {}", HumanFmt::Size(resume_offset))
         } else {
             String::new()
-        }
+        },
     );
 
     let cmd = DatabaseCommand::Download(DbCmdDownload {
@@ -2158,6 +2189,7 @@ async fn serve_unfinished_file(
 
         let mut finished = false;
         let mut bytes = 0;
+        let mut client_disconnected = false;
         let buf_size = config.buffer_size;
 
         // Late-joiner reads of an in-progress download are still sequential —
@@ -2166,7 +2198,7 @@ async fn serve_unfinished_file(
 
         let mut reader = tokio::io::BufReader::with_capacity(buf_size, &mut file);
 
-        loop {
+        'stream: loop {
             loop {
                 let mut buf = bytes::BytesMut::with_capacity(buf_size);
                 let ret = match reader.read_buf(&mut buf).await {
@@ -2180,13 +2212,14 @@ async fn serve_unfinished_file(
 
                 let buf = buf.freeze();
 
-                bytes += ret as u64;
                 assert_eq!(buf.len(), ret, "buffer length must match read bytes");
 
                 if let Err(tokio::sync::mpsc::error::SendError(_err)) = tx.send(Ok(buf)).await {
-                    info!("Receiver of stream task closed; cancelling stream...");
-                    return;
+                    client_disconnected = true;
+                    break 'stream;
                 }
+
+                bytes += ret as u64;
             }
 
             if finished {
@@ -2243,25 +2276,44 @@ async fn serve_unfinished_file(
         drop(counter);
 
         let elapsed = start.elapsed();
-        info!(
-            "Served new file {} from mirror {} for client {} in {} via channel (size={}, rate={})",
-            conn_details.debname,
-            conn_details.mirror,
-            conn_details.client,
-            HumanFmt::Time(elapsed.into()),
-            HumanFmt::Size(bytes),
-            HumanFmt::Rate(bytes, elapsed)
-        );
-
-        let cmd = DatabaseCommand::Delivery(DbCmdDelivery {
-            mirror: conn_details.mirror,
-            debname: conn_details.debname,
-            size: bytes,
-            elapsed,
-            partial: false,
-            client_ip: conn_details.client.ip(),
-        });
-        send_db_command(cmd).await;
+        let in_time = conn_details.request_received_at.elapsed();
+        let volatile = if conn_details.cached_flavor == CachedFlavor::Volatile {
+            "volatile "
+        } else {
+            ""
+        };
+        let aliased = match conn_details.aliased_host {
+            Some(alias) => format!(" aliased to host {alias}"),
+            None => String::new(),
+        };
+        if client_disconnected {
+            info!(
+                "Served downloading {volatile}file {} from mirror {}{aliased} for joining client {} in {} via channel ({})",
+                conn_details.debname,
+                conn_details.mirror,
+                conn_details.client,
+                HumanFmt::Time(in_time.into()),
+                rate_log::client_disconnect_segment(bytes, elapsed),
+            );
+        } else {
+            info!(
+                "Served downloading {volatile}file {} from mirror {}{aliased} for joining client {} in {} via channel ({})",
+                conn_details.debname,
+                conn_details.mirror,
+                conn_details.client,
+                HumanFmt::Time(in_time.into()),
+                rate_log::client_segment(bytes, elapsed),
+            );
+            let cmd = DatabaseCommand::Delivery(DbCmdDelivery {
+                mirror: conn_details.mirror,
+                debname: conn_details.debname,
+                size: bytes,
+                elapsed,
+                partial: false,
+                client_ip: conn_details.client.ip(),
+            });
+            send_db_command(cmd).await;
+        }
     });
 
     let mut response_builder = Response::builder()
@@ -2880,6 +2932,7 @@ async fn serve_new_file(
     );
     trace!("Forwarded request: {fwd_request:?}");
 
+    let mut upstream_request_sent = Instant::now();
     let mut fwd_response = match request_with_retry(&appstate.https_client, fwd_request).await {
         Ok(r) => r,
         Err(err) => {
@@ -2930,6 +2983,7 @@ async fn serve_new_file(
 
             trace!("Forwarded redirected request: {redirected_request:?}");
 
+            upstream_request_sent = Instant::now();
             let redirected_response =
                 match request_with_retry(&appstate.https_client, redirected_request).await {
                     Ok(r) => r,
@@ -3069,6 +3123,7 @@ async fn serve_new_file(
         let retry_request =
             build_fwd_request(&req_uri, host, &CacheFileStat::New, volatile_etag, 0, None);
 
+        upstream_request_sent = Instant::now();
         fwd_response = match request_with_retry(&appstate.https_client, retry_request).await {
             Ok(r) => r,
             Err(err) => {
@@ -3220,7 +3275,14 @@ async fn serve_new_file(
             let (parts, body) = fwd_response.into_parts();
 
             metrics::REQUESTS_PASSTHROUGH.increment();
-            let counted = ClientCountedBody::new(PassthroughBody::new(body));
+            let counted = ClientCountedBody::new(PassthroughBody::new(
+                body,
+                conn_details.request_received_at,
+                upstream_request_sent,
+                conn_details.mirror.format_authority().to_string(),
+                req_uri.path().to_owned(),
+                conn_details.client,
+            ));
 
             let rated = MaybeRated::new(
                 counted,
@@ -3468,6 +3530,7 @@ async fn serve_new_file(
                 (outfile, outpath),
                 dbarrier,
                 resume_offset,
+                upstream_request_sent,
             )
             .await;
         });
@@ -3952,11 +4015,12 @@ async fn pre_process_client_request(
     let (parts, _body) = req.into_parts();
     let req = Request::from_parts(parts, Empty::new());
 
-    let requested_host =
+    let (requested_host, passthrough_request_received_at) =
         match dispatch_request(req.uri().path(), requested_host, requested_port, &client).await {
             DispatchOutcome::Cache(plan) => {
                 let conn_details = ConnectionDetails {
                     client,
+                    request_received_at: plan.request_received_at,
                     mirror: plan.mirror,
                     aliased_host: plan.aliased_host,
                     debname: plan.debname,
@@ -3969,7 +4033,11 @@ async fn pre_process_client_request(
                 let (status, msg) = reason.response_parts();
                 return quick_response(status, msg);
             }
-            DispatchOutcome::Passthrough { requested_host, .. } => requested_host,
+            DispatchOutcome::Passthrough {
+                reason: _,
+                requested_host,
+                request_received_at,
+            } => (requested_host, request_received_at),
         };
 
     assert_eq!(req.method(), Method::GET, "Filtered at function start");
@@ -3991,12 +4059,14 @@ async fn pre_process_client_request(
         .insert(USER_AGENT, HeaderValue::from_static(APP_USER_AGENT));
 
     let mut parts_cloned = parts.clone();
+    let request_path = parts_cloned.uri.path().to_owned();
 
     // TODO: tweak http version?
     let fwd_request = Request::from_parts(parts, Empty::new());
 
     trace!("Forwarded request: {fwd_request:?}");
 
+    let fwd_request_sent = Instant::now();
     let fwd_response = match request_with_retry(&appstate.https_client, fwd_request).await {
         Ok(r) => r,
         Err(err) => {
@@ -4058,6 +4128,7 @@ async fn pre_process_client_request(
 
             trace!("Redirected request: {redirected_request:?}");
 
+            let redirected_request_sent = Instant::now();
             let redirected_response = match request_with_retry(
                 &appstate.https_client,
                 redirected_request,
@@ -4079,7 +4150,14 @@ async fn pre_process_client_request(
             let (parts, body) = redirected_response.into_parts();
 
             metrics::REQUESTS_PASSTHROUGH.increment();
-            let counted = ClientCountedBody::new(PassthroughBody::new(body));
+            let counted = ClientCountedBody::new(PassthroughBody::new(
+                body,
+                passthrough_request_received_at,
+                redirected_request_sent,
+                requested_host.to_string(),
+                request_path.clone(),
+                client,
+            ));
 
             let rated = MaybeRated::new(
                 counted,
@@ -4109,7 +4187,14 @@ async fn pre_process_client_request(
     let (parts, body) = fwd_response.into_parts();
 
     metrics::REQUESTS_PASSTHROUGH.increment();
-    let counted = ClientCountedBody::new(PassthroughBody::new(body));
+    let counted = ClientCountedBody::new(PassthroughBody::new(
+        body,
+        passthrough_request_received_at,
+        fwd_request_sent,
+        requested_host.to_string(),
+        request_path,
+        client,
+    ));
 
     let rated = MaybeRated::new(
         counted,

--- a/src/rate_log.rs
+++ b/src/rate_log.rs
@@ -1,0 +1,98 @@
+//! Shared formatting for the per-request rate-logging segments.
+//!
+//! Every download/serve/passthrough success log builds the trailing
+//! parenthesised part of its message from these segments and nothing else,
+//! so the format stays identical across the hyper, sendfile and splice
+//! backends.
+
+use coarsetime::Duration;
+
+use crate::humanfmt::HumanFmt;
+
+/// `upstream <size> at <rate>` -- body bytes received from the upstream mirror
+/// over the upstream-rate window.
+#[must_use]
+pub(crate) fn upstream_segment(bytes: u64, window: Duration) -> String {
+    format!(
+        "upstream {} at {}",
+        HumanFmt::Size(bytes),
+        HumanFmt::Rate(bytes, window)
+    )
+}
+
+/// `client <size> at <rate>` -- bytes delivered to the client over the
+/// client-rate window, for a fully-served response.
+#[must_use]
+pub(crate) fn client_segment(bytes: u64, window: Duration) -> String {
+    format!(
+        "client {} at {}",
+        HumanFmt::Size(bytes),
+        HumanFmt::Rate(bytes, window)
+    )
+}
+
+/// `client disconnected after <time> (<size>)` -- the client dropped before
+/// receiving the whole response; `bytes` is the best-effort count streamed
+/// toward it.
+#[must_use]
+pub(crate) fn client_disconnect_segment(bytes: u64, window: Duration) -> String {
+    format!(
+        "client disconnected after {} ({})",
+        HumanFmt::Time(window.into()),
+        HumanFmt::Size(bytes)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use coarsetime::Duration;
+
+    use super::{client_disconnect_segment, client_segment, upstream_segment};
+
+    #[test]
+    fn upstream_segment_format() {
+        // `coarsetime::Duration::from_millis` encodes sub-second time at ~0.977ms
+        // resolution, so from_millis(50) stores ~48.8ms -- the literals below
+        // reflect coarsetime's quantized output, not a mathematically exact 50ms.
+        assert_eq!(
+            upstream_segment(4_050_000, Duration::from_millis(50)),
+            "upstream 4.05MB at 82.9MB/s"
+        );
+    }
+
+    #[test]
+    fn client_segment_format() {
+        assert_eq!(
+            client_segment(1_000_000, Duration::from_millis(1000)),
+            "client 1.00MB at 1.00MB/s"
+        );
+    }
+
+    #[test]
+    fn client_disconnect_segment_format() {
+        // `coarsetime::Duration::from_millis` encodes sub-second time at ~0.977ms
+        // resolution; 18ms renders as the nearest representable window.
+        assert_eq!(
+            client_disconnect_segment(1_200_000, Duration::from_millis(18)),
+            "client disconnected after 17.6ms (1.20MB)"
+        );
+    }
+
+    #[test]
+    fn upstream_segment_zero_window() {
+        assert_eq!(
+            upstream_segment(500, Duration::from_millis(0)),
+            "upstream 500B at ???B/s"
+        );
+    }
+
+    #[test]
+    fn client_disconnect_segment_zero_bytes() {
+        // `coarsetime::Duration::from_millis` encodes sub-second time at ~0.977ms
+        // resolution; 5ms renders as the nearest representable window.
+        assert_eq!(
+            client_disconnect_segment(0, Duration::from_millis(5)),
+            "client disconnected after 4.88ms (0B)"
+        );
+    }
+}

--- a/src/request_dispatch.rs
+++ b/src/request_dispatch.rs
@@ -29,6 +29,7 @@
 
 use std::{cell::LazyCell, num::NonZero};
 
+use coarsetime::Instant;
 use http::StatusCode;
 use log::{info, trace};
 
@@ -55,6 +56,7 @@ pub(crate) struct CachePlan {
     pub(crate) debname: String,
     pub(crate) cached_flavor: CachedFlavor,
     pub(crate) layout: CacheLayout,
+    pub(crate) request_received_at: Instant,
     _private: (),
 }
 
@@ -143,6 +145,9 @@ pub(crate) enum DispatchOutcome {
         )]
         reason: PassthroughReason,
         requested_host: ClientHost,
+        // Consumed by both backends: `splice_simple_proxy` (`splice_conn.rs`,
+        // via the sendfile dispatch) and `PassthroughBody` (`main.rs`).
+        request_received_at: Instant,
     },
 }
 
@@ -173,6 +178,7 @@ pub(crate) async fn dispatch_request(
     requested_port: Option<NonZero<u16>>,
     client: &ClientInfo,
 ) -> DispatchOutcome {
+    let request_received_at = Instant::now();
     let cfg = global_config();
     let decision = decide_request(
         uri_path,
@@ -182,6 +188,7 @@ pub(crate) async fn dispatch_request(
         &cfg.aliases,
         cfg.reject_pdiff_requests,
         flat_blocklist::is_blocked,
+        request_received_at,
     );
     if let Some(origin) = decision.pending_origin {
         send_db_command(DatabaseCommand::Origin(DbCmdOrigin { origin })).await;
@@ -196,6 +203,10 @@ pub(crate) async fn dispatch_request(
 /// expressed as a closure and a return-value field respectively, so unit
 /// tests can drive every branch without standing up the DB task channel or
 /// the `RUNTIMEDETAILS`/`BLOCKLIST` `OnceLock`s.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "single production call site; grouping the params would not aid clarity"
+)]
 fn decide_request(
     uri_path: &str,
     requested_host: ClientHost,
@@ -204,6 +215,7 @@ fn decide_request(
     aliases: &'static [Alias],
     reject_pdiff_requests: bool,
     is_flat_blocked: impl FnOnce(&CacheHost, Option<NonZero<u16>>) -> bool,
+    request_received_at: Instant,
 ) -> Decision {
     trace!("Dispatching request from client {client}: host=`{requested_host}` path=`{uri_path}`");
 
@@ -267,6 +279,7 @@ fn decide_request(
                             debname: class.debname,
                             cached_flavor: class.cached_flavor,
                             layout: class.layout,
+                            request_received_at,
                             _private: (),
                         }),
                         pending_origin,
@@ -329,6 +342,7 @@ fn decide_request(
         outcome: DispatchOutcome::Passthrough {
             reason: passthrough_reason,
             requested_host,
+            request_received_at,
         },
         pending_origin: None,
     }
@@ -363,6 +377,7 @@ mod tests {
             &[],
             true,
             never_flat_blocked,
+            Instant::now(),
         );
         let DispatchOutcome::Cache(plan) = decision.outcome else {
             unreachable!("expected Cache outcome")
@@ -382,6 +397,7 @@ mod tests {
             &[],
             true,
             never_flat_blocked,
+            Instant::now(),
         );
         let DispatchOutcome::Cache(plan) = decision.outcome else {
             unreachable!("expected Cache outcome")
@@ -405,6 +421,7 @@ mod tests {
             &[],
             true,
             never_flat_blocked,
+            Instant::now(),
         );
         assert!(
             matches!(
@@ -430,6 +447,7 @@ mod tests {
             &[],
             true,
             never_flat_blocked,
+            Instant::now(),
         );
         assert!(
             matches!(
@@ -455,6 +473,7 @@ mod tests {
             &[],
             true,
             |_, _| true,
+            Instant::now(),
         );
         assert!(
             matches!(
@@ -480,6 +499,7 @@ mod tests {
             &[],
             true,
             never_flat_blocked,
+            Instant::now(),
         );
         assert!(
             matches!(decision.outcome, DispatchOutcome::Cache(_)),
@@ -498,6 +518,7 @@ mod tests {
             &[],
             true,
             never_flat_blocked,
+            Instant::now(),
         );
         assert!(
             matches!(
@@ -519,6 +540,7 @@ mod tests {
             &[],
             false,
             never_flat_blocked,
+            Instant::now(),
         );
         // Path is not a recognised structured shape (parser rejects), and the
         // pdiff gate is disabled, so this falls through to a plain Unrecognized
@@ -546,6 +568,7 @@ mod tests {
             &[],
             true,
             never_flat_blocked,
+            Instant::now(),
         );
         assert!(
             matches!(
@@ -571,6 +594,7 @@ mod tests {
             &[],
             true,
             never_flat_blocked,
+            Instant::now(),
         );
         assert!(
             matches!(

--- a/src/sendfile_conn.rs
+++ b/src/sendfile_conn.rs
@@ -29,6 +29,7 @@ use crate::http_helpers::{
 use crate::http_range::{ParsedRange, format_http_date, http_parse_range};
 use crate::humanfmt::HumanFmt;
 use crate::rate_checked_body::{InsufficientRate, RateCheckDirection, RateChecker};
+use crate::rate_log;
 use crate::request_dispatch::{DispatchOutcome, PassthroughReason, RejectReason, dispatch_request};
 use crate::tcp_cork_guard::CorkGuard;
 use crate::utils::{hint_sequential_read, is_peer_disconnect};
@@ -599,17 +600,20 @@ async fn try_sendfile_request(
         DispatchOutcome::Passthrough {
             reason: PassthroughReason::NonDebPool,
             requested_host: _,
+            request_received_at: _,
         } => return ZeroCopyResult::NotApplicable("unsupported pool filename"),
         // Structured mirror has claimed this host's `flat/` anchor; hand back
         // to hyper which will pass the request through uncached.
         DispatchOutcome::Passthrough {
             reason: PassthroughReason::FlatBlocked,
             requested_host: _,
+            request_received_at: _,
         } => return ZeroCopyResult::NotApplicable("flat host blocked by structured collision"),
         #[cfg(feature = "splice")]
         DispatchOutcome::Passthrough {
             reason: PassthroughReason::Unrecognized,
             requested_host,
+            request_received_at,
         } => {
             use crate::{
                 deb_mirror::{Mirror, MirrorKind},
@@ -632,8 +636,16 @@ async fn try_sendfile_request(
                 MirrorKind::Structured,
             );
 
-            return match splice_simple_proxy(stream, *conn_version, conn_action, &mirror, uri_path)
-                .await
+            return match splice_simple_proxy(
+                stream,
+                *conn_version,
+                conn_action,
+                &mirror,
+                uri_path,
+                client,
+                request_received_at,
+            )
+            .await
             {
                 Ok(()) => ZeroCopyResult::Served(conn_action),
                 Err(SpliceProxyError::Upstream) => ZeroCopyResult::Invalid {
@@ -683,6 +695,7 @@ async fn try_sendfile_request(
         DispatchOutcome::Passthrough {
             reason: PassthroughReason::Unrecognized,
             requested_host: _,
+            request_received_at: _,
         } => return ZeroCopyResult::NotApplicable("unrecognized resource path"),
     };
 
@@ -693,6 +706,7 @@ async fn try_sendfile_request(
 
     let conn_details = ConnectionDetails {
         client,
+        request_received_at: plan.request_received_at,
         mirror: plan.mirror,
         aliased_host: plan.aliased_host,
         debname: plan.debname,
@@ -1204,22 +1218,25 @@ pub(crate) async fn serve_file_via_sendfile(
     metrics::REQUESTS_SENDFILE.increment();
     let transfer_result = async_sendfile(stream, &file, content_start, content_length).await;
 
+    let in_time = conn_details.request_received_at.elapsed();
+    let volatile = if conn_details.cached_flavor == CachedFlavor::Volatile {
+        "volatile "
+    } else {
+        ""
+    };
     match transfer_result {
-        Ok(()) => {
+        Ok(transferred) => {
             metrics::SERVED_SENDFILE.increment();
             metrics::SERVED_TOTAL.increment();
             let elapsed = start.elapsed();
             info!(
-                "Served cached file {} from mirror {}{aliased} for client {} in {} via sendfile (size={}, rate={})",
+                "Served cached {volatile}file {} from mirror {}{aliased} for client {} in {} via sendfile ({})",
                 conn_details.debname,
                 conn_details.mirror,
                 conn_details.client,
-                HumanFmt::Time(elapsed.into()),
-                HumanFmt::Size(content_length),
-                HumanFmt::Rate(content_length, elapsed)
+                HumanFmt::Time(in_time.into()),
+                rate_log::client_segment(transferred, elapsed),
             );
-
-            // Update database
             let cmd = DatabaseCommand::Delivery(DbCmdDelivery {
                 mirror: conn_details.mirror.clone(),
                 debname: conn_details.debname.clone(),
@@ -1229,27 +1246,31 @@ pub(crate) async fn serve_file_via_sendfile(
                 client_ip: conn_details.client.ip(),
             });
             send_db_command(cmd).await;
-
             SendfileResult::Served(conn_action)
         }
-        Err(err) => {
+        Err((transferred, err)) => {
+            let elapsed = start.elapsed();
+            let segment = rate_log::client_disconnect_segment(transferred, elapsed);
             if is_peer_disconnect(&err) {
                 metrics::CLIENT_DISCONNECTED_MID_BODY.increment();
                 info!(
-                    "sendfile transfer cancelled for `{}` to client {}:  {}",
-                    file_path.display(),
+                    "Served cached {volatile}file {} from mirror {}{aliased} for client {} in {} via sendfile ({segment}):  {}",
+                    conn_details.debname,
+                    conn_details.mirror,
                     conn_details.client,
-                    ErrorReport(&err)
+                    HumanFmt::Time(in_time.into()),
+                    ErrorReport(&err),
                 );
             } else {
-                error!(
-                    "sendfile error serving `{}` to client {}:  {}",
-                    file_path.display(),
+                warn!(
+                    "Served cached {volatile}file {} from mirror {}{aliased} for client {} in {} via sendfile ({segment}):  {}",
+                    conn_details.debname,
+                    conn_details.mirror,
                     conn_details.client,
-                    ErrorReport(&err)
+                    HumanFmt::Time(in_time.into()),
+                    ErrorReport(&err),
                 );
             }
-            // Response already sent, just close the connection
             SendfileResult::AfterHeaderError
         }
     }
@@ -1625,18 +1646,21 @@ async fn sendfile_chunk_loop(
 
 /// Perform an async sendfile(2) operation, transferring `count` bytes from `file`
 /// starting at `offset` to the TCP socket.
+///
+/// Returns `Ok(n)` when all `n` bytes were transferred.  Returns `Err((n, e))`
+/// when an error occurred after `n` bytes had been transferred.
 pub(crate) async fn async_sendfile(
     socket: &TcpStream,
     file: &tokio::fs::File,
     offset: u64,
     count: u64,
-) -> std::io::Result<()> {
+) -> Result<u64, (u64, std::io::Error)> {
     let _counter = client_counter::ClientDownload::new();
 
     let Ok(mut file_offset) = i64::try_from(offset) else {
-        return Err(std::io::Error::new(
-            ErrorKind::InvalidInput,
-            "sendfile: offset exceeds i64::MAX",
+        return Err((
+            0,
+            std::io::Error::new(ErrorKind::InvalidInput, "sendfile: offset exceeds i64::MAX"),
         ));
     };
 
@@ -1646,12 +1670,24 @@ pub(crate) async fn async_sendfile(
         .min_download_rate
         .map(|rate| RateChecker::with_timeframe(rate, config.rate_check_timeframe));
 
-    match sendfile_chunk_loop(socket, file, &mut file_offset, count, &mut rate_checker).await? {
-        ChunkLoopOutcome::Complete => Ok(()),
-        ChunkLoopOutcome::Eof { transferred } => Err(std::io::Error::new(
-            ErrorKind::UnexpectedEof,
-            format!(
-                "sendfile: unexpected end of file (transferred {transferred}/{count} at offset {file_offset})"
+    match sendfile_chunk_loop(socket, file, &mut file_offset, count, &mut rate_checker)
+        .await
+        .map_err(|e| {
+            (
+                u64::try_from(file_offset)
+                    .unwrap_or(0)
+                    .saturating_sub(offset),
+                e,
+            )
+        })? {
+        ChunkLoopOutcome::Complete => Ok(count),
+        ChunkLoopOutcome::Eof { transferred } => Err((
+            transferred,
+            std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                format!(
+                    "sendfile: unexpected end of file (transferred {transferred}/{count} at offset {file_offset})"
+                ),
             ),
         )),
     }
@@ -1665,6 +1701,9 @@ pub(crate) async fn async_sendfile(
 ///
 /// `content_start` / `content_length` may describe a sub-range (HTTP Range).
 ///
+/// Returns `Ok(n)` when all `n` bytes were transferred.  Returns `Err((n, e))`
+/// when an error occurred after `n` bytes had been transferred.
+///
 /// The caller is responsible for bumping the appropriate request-count metric
 /// (`REQUESTS_SENDFILE` for the sendfile late-joiner path, no bump for the
 /// splice demoted-client path which already counted as `REQUESTS_SPLICE`).
@@ -1676,13 +1715,13 @@ pub(crate) async fn async_sendfile_unfinished(
     content_length: u64,
     mut receiver: tokio::sync::watch::Receiver<()>,
     status: std::sync::Arc<tokio::sync::RwLock<ActiveDownloadStatus>>,
-) -> std::io::Result<()> {
+) -> Result<u64, (u64, std::io::Error)> {
     let _counter = client_counter::ClientDownload::new();
 
     let Ok(mut file_offset) = i64::try_from(content_start) else {
-        return Err(std::io::Error::new(
-            ErrorKind::InvalidInput,
-            "sendfile: offset exceeds i64::MAX",
+        return Err((
+            0,
+            std::io::Error::new(ErrorKind::InvalidInput, "sendfile: offset exceeds i64::MAX"),
         ));
     };
 
@@ -1709,9 +1748,10 @@ pub(crate) async fn async_sendfile_unfinished(
             Ok(_) => {
                 metrics::CACHE_NON_REGULAR.increment();
                 error!("Cache file `{}` is not a regular file", file_path.display());
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "Not a regular file",
+                let transferred = content_length - remaining;
+                return Err((
+                    transferred,
+                    std::io::Error::new(std::io::ErrorKind::InvalidData, "Not a regular file"),
                 ));
             }
             Err(errno) => {
@@ -1731,9 +1771,13 @@ pub(crate) async fn async_sendfile_unfinished(
             if finished {
                 // The download claims to be done but the file is shorter than
                 // expected — treat as unexpected EOF.
-                return Err(std::io::Error::new(
-                    ErrorKind::UnexpectedEof,
-                    "sendfile: file shorter than expected after download finished",
+                let transferred = content_length - remaining;
+                return Err((
+                    transferred,
+                    std::io::Error::new(
+                        ErrorKind::UnexpectedEof,
+                        "sendfile: file shorter than expected after download finished",
+                    ),
                 ));
             }
             // Wait for the sender to notify us of new data on disk.
@@ -1751,14 +1795,20 @@ pub(crate) async fn async_sendfile_unfinished(
                         }
                         ActiveDownloadStatus::Aborted(_) => {
                             drop(st);
-                            return Err(std::io::Error::other(
-                                "sendfile: upstream download aborted",
+                            let transferred = content_length - remaining;
+                            return Err((
+                                transferred,
+                                std::io::Error::other("sendfile: upstream download aborted"),
                             ));
                         }
                         ActiveDownloadStatus::Init(_) | ActiveDownloadStatus::Download { .. } => {
                             drop(st);
-                            return Err(std::io::Error::other(
-                                "sendfile: unexpected download state for demoted client file-serve",
+                            let transferred = content_length - remaining;
+                            return Err((
+                                transferred,
+                                std::io::Error::other(
+                                    "sendfile: unexpected download state for demoted client file-serve",
+                                ),
                             ));
                         }
                     }
@@ -1769,7 +1819,15 @@ pub(crate) async fn async_sendfile_unfinished(
         // Transfer what is currently available via the shared sendfile loop.
         let outcome =
             sendfile_chunk_loop(socket, file, &mut file_offset, sendable, &mut rate_checker)
-                .await?;
+                .await
+                .map_err(|e| {
+                    (
+                        u64::try_from(file_offset)
+                            .unwrap_or(0)
+                            .saturating_sub(content_start),
+                        e,
+                    )
+                })?;
         let sent = match outcome {
             ChunkLoopOutcome::Complete => sendable,
             ChunkLoopOutcome::Eof { transferred } => {
@@ -1788,7 +1846,11 @@ pub(crate) async fn async_sendfile_unfinished(
                     }
                 };
                 if is_aborted {
-                    return Err(std::io::Error::other("sendfile: upstream download aborted"));
+                    let already_sent = content_length - remaining;
+                    return Err((
+                        already_sent + transferred,
+                        std::io::Error::other("sendfile: upstream download aborted"),
+                    ));
                 }
                 if is_finished {
                     finished = true;
@@ -1801,7 +1863,7 @@ pub(crate) async fn async_sendfile_unfinished(
             .expect("should not have transferred more bytes than requested");
     }
 
-    Ok(())
+    Ok(content_length)
 }
 
 /// Serve a file that is currently being downloaded by another task, using
@@ -2053,21 +2115,25 @@ async fn serve_unfinished_sendfile(
     )
     .await;
 
+    let in_time = conn_details.request_received_at.elapsed();
+    let volatile = if conn_details.cached_flavor == CachedFlavor::Volatile {
+        "volatile "
+    } else {
+        ""
+    };
     match transfer_result {
-        Ok(()) => {
+        Ok(transferred) => {
             metrics::SERVED_SENDFILE.increment();
             metrics::SERVED_TOTAL.increment();
             let elapsed = start.elapsed();
             info!(
-                "Served downloading file {} from mirror {}{aliased} for joining client {} in {} via sendfile (size={}, rate={})",
+                "Served downloading {volatile}file {} from mirror {}{aliased} for joining client {} in {} via sendfile ({})",
                 conn_details.debname,
                 conn_details.mirror,
                 conn_details.client,
-                HumanFmt::Time(elapsed.into()),
-                HumanFmt::Size(content_length),
-                HumanFmt::Rate(content_length, elapsed)
+                HumanFmt::Time(in_time.into()),
+                rate_log::client_segment(transferred, elapsed),
             );
-
             let cmd = DatabaseCommand::Delivery(DbCmdDelivery {
                 mirror: conn_details.mirror.clone(),
                 debname: conn_details.debname.clone(),
@@ -2077,26 +2143,29 @@ async fn serve_unfinished_sendfile(
                 client_ip: conn_details.client.ip(),
             });
             send_db_command(cmd).await;
-
             ZeroCopyResult::Served(conn_action)
         }
-        Err(err) => {
+        Err((transferred, err)) => {
+            let elapsed = start.elapsed();
+            let segment = rate_log::client_disconnect_segment(transferred, elapsed);
             if is_peer_disconnect(&err) {
                 metrics::CLIENT_DISCONNECTED_MID_BODY.increment();
                 info!(
-                    "Joining client {} disconnected while serving downloading file {} from mirror {}{aliased}:  {}",
-                    conn_details.client,
+                    "Served downloading {volatile}file {} from mirror {}{aliased} for joining client {} in {} via sendfile ({segment}):  {}",
                     conn_details.debname,
                     conn_details.mirror,
-                    ErrorReport(&err)
+                    conn_details.client,
+                    HumanFmt::Time(in_time.into()),
+                    ErrorReport(&err),
                 );
             } else {
                 warn!(
-                    "Failed to sendfile downloading file {} from mirror {}{aliased} to joining client {}:  {}",
+                    "Served downloading {volatile}file {} from mirror {}{aliased} for joining client {} in {} via sendfile ({segment}):  {}",
                     conn_details.debname,
                     conn_details.mirror,
                     conn_details.client,
-                    ErrorReport(&err)
+                    HumanFmt::Time(in_time.into()),
+                    ErrorReport(&err),
                 );
             }
             ZeroCopyResult::AfterHeaderError

--- a/src/splice_conn.rs
+++ b/src/splice_conn.rs
@@ -51,6 +51,7 @@ use crate::ktls;
 use crate::ktls_handshake::{discard_incoming, encode_tls_data, grow_incoming};
 use crate::limits::{MAX_UPSTREAM_HEADER_SIZE, MAX_UPSTREAM_HEADERS};
 use crate::rate_checked_body::{InsufficientRate, RateCheckDirection, RateChecker};
+use crate::rate_log;
 #[cfg(feature = "ktls")]
 use crate::secure_vec::SecureVec;
 use crate::sendfile_conn::RangeRequestHeaders;
@@ -64,7 +65,7 @@ use crate::utils::{
 };
 use crate::xattr_helpers;
 use crate::{
-    APP_USER_AGENT, APP_VIA, ActiveDownloadStatus, AppState, ContentLength, Never,
+    APP_USER_AGENT, APP_VIA, ActiveDownloadStatus, AppState, ClientInfo, ContentLength, Never,
     OriginateOutcome, SCHEME_CACHE, Scheme, SchemeKey, SchemeKeyRef,
     VOLATILE_UNKNOWN_CONTENT_LENGTH_UPPER, cache_metadata, client_counter,
     content_type_for_cached_file, global_cache_quota, global_config, is_host_allowed_cached,
@@ -1164,6 +1165,11 @@ async fn unbuffered_ktls_request(
     // TLS 1.3 typically sends 1-2 NewSessionTicket records; a handful of iterations
     // covers the legitimate case while still catching pathological peers quickly.
     let mut post_handshake_rounds = 0u32;
+    // Instant the encrypted HTTP request was transmitted - start of the
+    // upstream-rate window. Set in the `WriteTraffic` arm below; every other
+    // arm of the request-send loop continues or returns, so the compiler can
+    // prove definite initialisation by the time the post-loop read occurs.
+    let req_sent: Option<coarsetime::Instant>;
 
     loop {
         /// Cap on state-machine rounds between handshake-complete and
@@ -1233,6 +1239,7 @@ async fn unbuffered_ktls_request(
                 write_all_to_stream(tcp, &outgoing[..enc_len], WritePhase::Header)
                     .await
                     .map_err(KtlsError::KtlsSetupFailed)?;
+                req_sent = Some(coarsetime::Instant::now());
                 break;
             }
             ConnectionState::BlockedHandshake => {
@@ -1407,12 +1414,13 @@ async fn unbuffered_ktls_request(
     // --- Parse response to check status before setting up kTLS ---
     // Malformed HTTP from the upstream is not a kTLS issue — surface it as
     // UpstreamProtocolError so the host stays eligible for kTLS retries.
-    let response = parse_upstream_response(&header_buf, header_end).map_err(|err| {
+    let mut response = parse_upstream_response(&header_buf, header_end).map_err(|err| {
         KtlsError::UpstreamProtocolError(std::io::Error::new(
             err.kind(),
             format!("kTLS upstream protocol error:  {err}"),
         ))
     })?;
+    response.request_sent_at = req_sent;
 
     if response.status_code != 200 || response.content_length.is_none_or(|ct| ct == 0) {
         // Non-spliceable response: the caller will reconnect via the standard
@@ -1789,6 +1797,9 @@ struct UpstreamResponse {
     location: Option<String>,
     connection_close: bool,
     is_chunked: bool,
+    /// Instant the upstream request was sent - start of the upstream-rate
+    /// window. `None` only on responses built by the bare parser in tests.
+    request_sent_at: Option<coarsetime::Instant>,
 }
 
 /// Parse upstream HTTP response headers.
@@ -1862,12 +1873,13 @@ fn parse_upstream_response(buf: &[u8], header_end: usize) -> std::io::Result<Ups
         location,
         connection_close,
         is_chunked,
+        request_sent_at: None,
     })
 }
 
 enum DeliveryResult {
-    Success,
-    Failure,
+    Success(u64),
+    Failure(u64),
 }
 
 /// Splice data from upstream TCP socket to client socket, with zero-copy tee to a cache file.
@@ -1890,7 +1902,7 @@ async fn splice_proxy_body(
     mut dbarrier: DownloadBarrier,
     range_filter: &SpliceRangeFilter,
     cache_path: &Path,
-) -> std::io::Result<(DownloadBarrier, Option<DemotedClientHandle>, bool)> {
+) -> std::io::Result<(DownloadBarrier, Option<DemotedClientHandle>, bool, u64)> {
     // Dropped at the demotion transition so the spawned `serve_remaining_from_file`
     // task's own `ClientDownload` (in `async_sendfile_unfinished`) takes over the
     // accounting cleanly — see the `ClientStatus::Demoted` branch below.
@@ -2136,7 +2148,13 @@ async fn splice_proxy_body(
     }
 
     let client_disconnected = matches!(client_status, ClientStatus::Disconnected);
-    Ok((dbarrier, demoted_handle, client_disconnected))
+    let client_bytes_written = range_filter.send - client_remaining;
+    Ok((
+        dbarrier,
+        demoted_handle,
+        client_disconnected,
+        client_bytes_written,
+    ))
 }
 
 /// Writes the entire buffer to the cache file via pwrite at the specified offset.
@@ -2254,7 +2272,7 @@ async fn splice_proxy_body_tls(
     mut dbarrier: DownloadBarrier,
     range_filter: &SpliceRangeFilter,
     cache_path: &Path,
-) -> std::io::Result<(DownloadBarrier, Option<DemotedClientHandle>, bool)> {
+) -> std::io::Result<(DownloadBarrier, Option<DemotedClientHandle>, bool, u64)> {
     // Dropped at the demotion transition so the spawned `serve_remaining_from_file`
     // task's own `ClientDownload` (in `async_sendfile_unfinished`) takes over the
     // accounting cleanly — see the `ClientStatus::Demoted` branch below.
@@ -2504,7 +2522,13 @@ async fn splice_proxy_body_tls(
     }
 
     let client_disconnected = matches!(client_status, ClientStatus::Disconnected);
-    Ok((dbarrier, demoted_handle, client_disconnected))
+    let client_bytes_written = range_filter.send - client_remaining;
+    Ok((
+        dbarrier,
+        demoted_handle,
+        client_disconnected,
+        client_bytes_written,
+    ))
 }
 
 /// Duplicate the client socket fd and spawn a task that serves remaining bytes
@@ -2574,7 +2598,7 @@ async fn serve_remaining_from_file(
                 "splice proxy: failed to open cache file `{}` for demoted client:  {err}",
                 cache_path.display()
             );
-            return DeliveryResult::Failure;
+            return DeliveryResult::Failure(0);
         }
     };
 
@@ -2596,13 +2620,13 @@ async fn serve_remaining_from_file(
     )
     .await
     {
-        Ok(()) => {
+        Ok(bytes) => {
             debug!(
                 "splice proxy: demoted client file-serve complete, sent {content_length} bytes from cache offset {content_start}"
             );
-            DeliveryResult::Success
+            DeliveryResult::Success(bytes)
         }
-        Err(err) => {
+        Err((bytes, err)) => {
             if is_peer_disconnect(&err) {
                 metrics::CLIENT_DISCONNECTED_MID_BODY.increment();
                 debug!(
@@ -2615,7 +2639,7 @@ async fn serve_remaining_from_file(
                 );
             }
 
-            DeliveryResult::Failure
+            DeliveryResult::Failure(bytes)
         }
     }
 }
@@ -3048,10 +3072,11 @@ async fn send_and_read_headers(
         volatile_cond,
     )
     .await?;
+    let request_sent_at = coarsetime::Instant::now();
 
     let mut hdr_buf = BytesMut::with_capacity(MAX_UPSTREAM_HEADER_SIZE);
     let hdr_end = read_upstream_response_headers(up, &mut hdr_buf).await?;
-    let resp = parse_upstream_response(&hdr_buf, hdr_end).map_err(|err| {
+    let mut resp = parse_upstream_response(&hdr_buf, hdr_end).map_err(|err| {
         metrics::UPSTREAM_PROTOCOL_VIOLATION.increment();
         warn_once_or_info!("splice proxy: upstream {host_authority} sent malformed HTTP:  {err}");
         err
@@ -3066,6 +3091,7 @@ async fn send_and_read_headers(
         metrics::BYTES_DOWNLOADED_UPSTREAM.increment_by(body_prefix_len);
     }
     metrics::record_upstream_status(resp.status_code);
+    resp.request_sent_at = Some(request_sent_at);
     Ok((resp, hdr_buf, hdr_end))
 }
 
@@ -3299,7 +3325,7 @@ async fn forward_upstream_body(
     upstream: &mut UpstreamConn,
     client: &TcpStream,
     count: u64,
-) -> std::io::Result<()> {
+) -> std::io::Result<u64> {
     let config = global_config();
     // `Vec::with_capacity` reserves uninitialized backing storage; `read_buf`
     // fills bytes into the spare capacity via `BufMut`, so the buffer is
@@ -3367,7 +3393,7 @@ async fn forward_upstream_body(
             .expect("read should not return more than requested");
     }
 
-    Ok(())
+    Ok(count)
 }
 
 /// Forward body bytes from upstream to client until EOF, with a size cap.
@@ -3376,7 +3402,7 @@ async fn forward_upstream_body_until_eof(
     upstream: &mut UpstreamConn,
     client: &TcpStream,
     max_bytes: usize,
-) -> std::io::Result<()> {
+) -> std::io::Result<u64> {
     let config = global_config();
     let mut buf = BytesMut::with_capacity(TLS_READ_BUF_SIZE);
     let mut total = 0;
@@ -3433,7 +3459,7 @@ async fn forward_upstream_body_until_eof(
         metrics::BYTES_SERVED_PASSTHROUGH.increment_by(n as u64);
     }
 
-    Ok(())
+    Ok(total)
 }
 
 /// State for the chunked transfer-encoding decoder.
@@ -3464,7 +3490,7 @@ async fn forward_upstream_chunked_body(
     client: &TcpStream,
     body_prefix: &[u8],
     max_bytes: usize,
-) -> std::io::Result<()> {
+) -> std::io::Result<u64> {
     let config = global_config();
     let mut rate_checker = config
         .min_download_rate
@@ -3476,6 +3502,8 @@ async fn forward_upstream_chunked_body(
     let mut state = ChunkedState::ReadingSize;
     let mut size_buf = Vec::<u8>::with_capacity(32);
     let mut total = Saturating(0);
+    // Tracks raw bytes (framing + data) written to the client.
+    let mut client_total: u64 = 0;
 
     // Process a slice of bytes through the state machine, forwarding them to the
     // client.  Returns `true` when the terminal chunk has been fully consumed.
@@ -3625,6 +3653,7 @@ async fn forward_upstream_chunked_body(
                     std::io::Error::new(e.kind(), format!("chunked forward: client write:  {e}"))
                 })?;
                 metrics::BYTES_SERVED_PASSTHROUGH.increment_by(data.len() as u64);
+                client_total += data.len() as u64;
             }
             done
         }};
@@ -3632,7 +3661,7 @@ async fn forward_upstream_chunked_body(
 
     // Bootstrap: process bytes that arrived with the response headers.
     if process_buf!(body_prefix) {
-        return Ok(());
+        return Ok(client_total);
     }
 
     let mut buf = BytesMut::with_capacity(TLS_READ_BUF_SIZE);
@@ -3666,7 +3695,7 @@ async fn forward_upstream_chunked_body(
         }
 
         if process_buf!(&buf[..n]) {
-            return Ok(());
+            return Ok(client_total);
         }
     }
 }
@@ -4326,7 +4355,7 @@ async fn splice_proxy_drive(
             let already_sent = body_prefix.len() as u64;
             let remaining = cl.saturating_sub(already_sent);
             if remaining > 0 {
-                forward_upstream_body(&mut upstream, client_stream, remaining)
+                let _forwarded = forward_upstream_body(&mut upstream, client_stream, remaining)
                     .await
                     .map_err(|err| {
                         SpliceProxyError::AfterHeaderClient(err, "passthrough remaining body")
@@ -4334,7 +4363,7 @@ async fn splice_proxy_drive(
             }
         } else if upstream_resp.is_chunked {
             // Chunked encoding: forward raw framing, detect termination
-            forward_upstream_chunked_body(
+            let _forwarded = forward_upstream_chunked_body(
                 &mut upstream,
                 client_stream,
                 body_prefix,
@@ -4359,11 +4388,12 @@ async fn splice_proxy_drive(
                 metrics::BYTES_SERVED_PASSTHROUGH.increment_by(body_prefix.len() as u64);
             }
             upstream.unset_poolable();
-            forward_upstream_body_until_eof(&mut upstream, client_stream, VOLATILE_BODY_MAX)
-                .await
-                .map_err(|err| {
-                    SpliceProxyError::AfterHeaderClient(err, "passthrough body until EOF")
-                })?;
+            let _forwarded =
+                forward_upstream_body_until_eof(&mut upstream, client_stream, VOLATILE_BODY_MAX)
+                    .await
+                    .map_err(|err| {
+                        SpliceProxyError::AfterHeaderClient(err, "passthrough body until EOF")
+                    })?;
         }
 
         // InitBarrier fires on return, which is correct: nothing was cached
@@ -4870,6 +4900,25 @@ async fn splice_proxy_drive(
 
     let start = coarsetime::Instant::now();
 
+    // Per-request rate-logging timestamps.
+    //   - `t_req_sent`: start of the upstream-rate window (instant the upstream
+    //     request was sent; falls back to `start` only for bare-parser
+    //     responses, i.e. tests).
+    //   - `t_upstream_done`: end of the upstream-rate window. Initialised here
+    //     so the case where the splice loop never runs (whole body arrived with
+    //     the headers) still has a sane figure; reassigned right after the
+    //     splice body block when it does run.
+    //   - `t_client_first`: start of the client-rate window (just before the
+    //     response-header write below).
+    //   - `t_client_done`: end of the client-rate window; first set after the
+    //     prefix writes, then reassigned after the splice body block and after
+    //     the demoted file-serve task completes.
+    //   - `client_bytes_sent`: best-effort count of body bytes written toward
+    //     the client, for the disconnect segment.
+    let t_req_sent = upstream_resp.request_sent_at.unwrap_or(start);
+    let mut t_upstream_done = coarsetime::Instant::now();
+    let mut client_bytes_sent: u64 = 0;
+
     if resume_offset > 0 {
         #[expect(clippy::cast_precision_loss, reason = "only for display purpose")]
         let resume_percent = resume_offset as f32 / total_content_length.get() as f32 * 100.0;
@@ -4948,6 +4997,8 @@ async fn splice_proxy_drive(
     // ends up flowing through `splice_proxy_body{,_tls}`, the body-prefix
     // direct write, or the kTLS-extra-body direct write.
     metrics::REQUESTS_SPLICE.increment();
+    // Start of the client-rate window: the first byte heading to the client.
+    let t_client_first = coarsetime::Instant::now();
     write_all_to_stream(
         client_stream,
         response_headers.as_bytes(),
@@ -4978,14 +5029,22 @@ async fn splice_proxy_drive(
                     SpliceProxyError::AfterHeaderIo
                 })?;
 
-            async_sendfile(
+            match async_sendfile(
                 client_stream,
                 &partial_reader,
                 send_start,
                 send_end - send_start,
             )
             .await
-            .map_err(|err| SpliceProxyError::AfterHeaderClient(err, "resume sendfile to client"))?;
+            {
+                Ok(sent) => client_bytes_sent += sent,
+                Err((_sent, err)) => {
+                    return Err(SpliceProxyError::AfterHeaderClient(
+                        err,
+                        "resume sendfile to client",
+                    ));
+                }
+            }
         }
     }
 
@@ -5048,6 +5107,7 @@ async fn splice_proxy_drive(
                 prefix_client_failed = true;
             } else {
                 metrics::BYTES_SERVED_SPLICE.increment_by(client_slice.len() as u64);
+                client_bytes_sent += client_slice.len() as u64;
             }
         }
 
@@ -5103,6 +5163,7 @@ async fn splice_proxy_drive(
                 prefix_client_failed = true;
             } else {
                 metrics::BYTES_SERVED_SPLICE.increment_by(client_slice.len() as u64);
+                client_bytes_sent += client_slice.len() as u64;
             }
         }
 
@@ -5120,6 +5181,11 @@ async fn splice_proxy_drive(
 
     // Uncork before entering the splice loop, which uses SPLICE_F_MORE for coalescing
     drop(cork);
+
+    // Client-rate-window end after the prefix / kTLS-extra-body writes; covers
+    // the case where the splice loop never runs (whole body in the prefix).
+    // Reassigned after the splice body block and the demoted file-serve task.
+    let mut t_client_done = coarsetime::Instant::now();
 
     // Transfer the remaining body
     let (demoted_handle, body_client_disconnected) = if splice_count > 0 {
@@ -5154,7 +5220,7 @@ async fn splice_proxy_drive(
         // rename step; on a structured rate-timeout it's already consumed into
         // `Aborted(MirrorDownloadRate)`; on any other io::Error it's dropped
         // inside the callee and the Drop impl records `AlreadyLoggedJustFail`.
-        let (returned_dbarrier, demoted_handle, body_client_disconnected) =
+        let (returned_dbarrier, demoted_handle, body_client_disconnected, body_client_bytes) =
             if let Some(tcp_upstream) = upstream.as_tcp() {
                 // Zero-copy path for TCP (plain or kTLS)
                 splice_proxy_body(
@@ -5184,6 +5250,12 @@ async fn splice_proxy_drive(
             }
             .map_err(|err| SpliceProxyError::AfterHeaderClient(err, "splice body transfer"))?;
         dbarrier = returned_dbarrier;
+        // The splice body block ran: the upstream-rate and client-rate windows
+        // both end here. The demoted-client case reassigns `t_client_done`
+        // again after the file-serve task completes.
+        t_upstream_done = coarsetime::Instant::now();
+        t_client_done = t_upstream_done;
+        client_bytes_sent += body_client_bytes;
         (demoted_handle, body_client_disconnected)
     } else {
         (None, false)
@@ -5264,9 +5336,15 @@ async fn splice_proxy_drive(
     // No demotion means the splice loop served the client itself (or there
     // was no body to splice) — that's a success, not a failure.
     let demoted_client_succeeded = if let Some(handle) = demoted_handle {
-        match handle.await {
-            Ok(DeliveryResult::Success) => true,
-            Ok(DeliveryResult::Failure) => false,
+        let succeeded = match handle.await {
+            Ok(DeliveryResult::Success(bytes)) => {
+                client_bytes_sent += bytes;
+                true
+            }
+            Ok(DeliveryResult::Failure(bytes)) => {
+                client_bytes_sent += bytes;
+                false
+            }
             Err(err) => {
                 error!(
                     "splice proxy: demoted client file-serve task panicked:  {}",
@@ -5274,7 +5352,11 @@ async fn splice_proxy_drive(
                 );
                 false
             }
-        }
+        };
+        // The demoted file-serve task is the last thing to write to the
+        // client, so the client-rate window ends here.
+        t_client_done = coarsetime::Instant::now();
+        succeeded
     } else {
         true
     };
@@ -5282,8 +5364,29 @@ async fn splice_proxy_drive(
     let client_succeeded =
         !prefix_client_failed && !body_client_disconnected && demoted_client_succeeded;
 
+    let in_time = conn_details.request_received_at.elapsed();
+    let volatile = if conn_details.cached_flavor == CachedFlavor::Volatile {
+        "volatile "
+    } else {
+        ""
+    };
+    let upstream = rate_log::upstream_segment(
+        body_content_length.get(),
+        t_upstream_done.duration_since(t_req_sent),
+    );
+    let client = if client_succeeded {
+        rate_log::client_segment(
+            response_content_length,
+            t_client_done.duration_since(t_client_first),
+        )
+    } else {
+        rate_log::client_disconnect_segment(
+            client_bytes_sent,
+            t_client_done.duration_since(t_client_first),
+        )
+    };
     info!(
-        "Splice proxy{tls_label}: {} {} from mirror {} for client {} in {} (size={}, rate={}{})",
+        "Splice proxy{tls_label}: {} {volatile}{} from mirror {} for client {} in {} ({upstream}, {client}){}",
         if client_succeeded {
             "served and cached"
         } else {
@@ -5292,14 +5395,12 @@ async fn splice_proxy_drive(
         conn_details.debname,
         conn_details.mirror,
         conn_details.client,
-        HumanFmt::Time(elapsed.into()),
-        HumanFmt::Size(total_content_length.get()),
-        HumanFmt::Rate(body_content_length.get(), elapsed),
+        HumanFmt::Time(in_time.into()),
         if resume_offset > 0 {
             format!(", resumed from {}", HumanFmt::Size(resume_offset))
         } else {
             String::new()
-        }
+        },
     );
 
     if !client_succeeded {
@@ -5571,6 +5672,12 @@ async fn handle_volatile_buffered_download(
         .expect("constant fits"); // TODO: const conversion once stable
     let body_prefix = &header_buf[header_end..];
 
+    // Capture t_req_sent before buffering so the upstream-rate window is never
+    // inverted. The fallback is a pre-read now() so t_req_sent <= t_upstream_done.
+    let t_req_sent = upstream_resp
+        .request_sent_at
+        .unwrap_or_else(coarsetime::Instant::now);
+
     // Buffer the entire body into memory.
     let body = if upstream_resp.is_chunked {
         read_dechunk_body_to_vec(upstream, body_prefix, max_bytes).await
@@ -5586,6 +5693,8 @@ async fn handle_volatile_buffered_download(
         );
         SpliceProxyError::Upstream
     })?;
+
+    let t_upstream_done = coarsetime::Instant::now();
 
     // Drop upstream early to free the socket.
     // (PoolGuard::drop returns the connection to pool if still poolable.)
@@ -5809,6 +5918,7 @@ async fn handle_volatile_buffered_download(
         StatusCode::OK
     });
     metrics::REQUESTS_SPLICE.increment();
+    let t_client_first = coarsetime::Instant::now();
     write_all_to_stream(
         client_stream,
         response_headers.as_bytes(),
@@ -5835,6 +5945,7 @@ async fn handle_volatile_buffered_download(
         .map_err(|err| SpliceProxyError::AfterHeaderClient(err, "volatile body to client"))?;
         metrics::BYTES_SERVED_SPLICE.increment_by(body_slice.len() as u64);
     }
+    let t_client_done = coarsetime::Instant::now();
     metrics::SERVED_SPLICE.increment();
     metrics::SERVED_TOTAL.increment();
 
@@ -5892,13 +6003,26 @@ async fn handle_volatile_buffered_download(
 
     let elapsed = start.elapsed();
 
+    let in_time = conn_details.request_received_at.elapsed();
+    let volatile = if conn_details.cached_flavor == CachedFlavor::Volatile {
+        "volatile "
+    } else {
+        ""
+    };
     info!(
-        "Splice proxy{tls_label}: served and cached {} from mirror {} for client {} in {} (size={}, buffered volatile)",
+        "Splice proxy{tls_label}: served and cached {volatile}{} from mirror {} for client {} in {} ({}, {})",
         conn_details.debname,
         conn_details.mirror,
         conn_details.client,
-        HumanFmt::Time(elapsed.into()),
-        HumanFmt::Size(total_content_length.get()),
+        HumanFmt::Time(in_time.into()),
+        rate_log::upstream_segment(
+            total_content_length.get(),
+            t_upstream_done.duration_since(t_req_sent),
+        ),
+        rate_log::client_segment(
+            response_content_length as u64,
+            t_client_done.duration_since(t_client_first),
+        ),
     );
 
     // Record download in database (mirrors download_file() in main.rs).
@@ -6032,11 +6156,17 @@ pub(crate) async fn splice_simple_proxy(
     conn_action: ConnectionAction,
     mirror: &Mirror,
     upstream_path: &str,
+    client: ClientInfo,
+    request_received_at: coarsetime::Instant,
 ) -> Result<(), SpliceProxyError> {
     let host_authority = mirror.format_authority();
 
     let (up, resp, hdr_buf, hdr_end, _label, poolable) =
         standard_upstream_connect(mirror, &host_authority, upstream_path, 0, None, None).await?;
+
+    let t_req_sent = resp
+        .request_sent_at
+        .unwrap_or_else(coarsetime::Instant::now);
 
     let port = mirror_port(mirror, up.is_tls());
 
@@ -6069,6 +6199,7 @@ pub(crate) async fn splice_simple_proxy(
 
     metrics::record_client_status(resp.status_code);
     metrics::REQUESTS_PASSTHROUGH.increment();
+    let t_client_first = coarsetime::Instant::now();
     write_all_to_stream(
         client_stream,
         rewritten_headers.as_bytes(),
@@ -6093,11 +6224,12 @@ pub(crate) async fn splice_simple_proxy(
     // request/response smuggling), and the header rewrite above already
     // strips Content-Length in that case — so we must frame the body the
     // same way the client will be reading it.
-    if resp.is_chunked {
-        // Chunked encoding: forward raw framing, detect termination
+    let forwarded: u64 = if resp.is_chunked {
+        // Chunked encoding: forward raw framing, detect termination.
+        // body_prefix is passed into the helper, so its return includes the prefix.
         forward_upstream_chunked_body(&mut upstream, client_stream, body_prefix, VOLATILE_BODY_MAX)
             .await
-            .map_err(|err| SpliceProxyError::AfterHeaderClient(err, "simple-proxy chunked body"))?;
+            .map_err(|err| SpliceProxyError::AfterHeaderClient(err, "simple-proxy chunked body"))?
     } else if let Some(cl) = resp.content_length {
         if !body_prefix.is_empty() {
             write_all_to_stream_rated(
@@ -6116,14 +6248,18 @@ pub(crate) async fn splice_simple_proxy(
         let already_sent = body_prefix.len() as u64;
         let remaining = cl.saturating_sub(already_sent);
         if remaining > 0 {
-            forward_upstream_body(&mut upstream, client_stream, remaining)
+            let helper_bytes = forward_upstream_body(&mut upstream, client_stream, remaining)
                 .await
                 .map_err(|err| {
                     SpliceProxyError::AfterHeaderClient(err, "simple-proxy remaining body")
                 })?;
+            body_prefix.len() as u64 + helper_bytes
+        } else {
+            body_prefix.len() as u64
         }
     } else {
-        // No Content-Length and not chunked: read until EOF
+        // No Content-Length and not chunked: read until EOF.
+        // body_prefix is written separately before the helper call.
         if !body_prefix.is_empty() {
             write_all_to_stream_rated(
                 client_stream,
@@ -6139,12 +6275,23 @@ pub(crate) async fn splice_simple_proxy(
             metrics::BYTES_SERVED_PASSTHROUGH.increment_by(body_prefix.len() as u64);
         }
         upstream.unset_poolable();
-        forward_upstream_body_until_eof(&mut upstream, client_stream, VOLATILE_BODY_MAX)
-            .await
-            .map_err(|err| {
-                SpliceProxyError::AfterHeaderClient(err, "simple-proxy body until EOF")
-            })?;
-    }
+        let helper_bytes =
+            forward_upstream_body_until_eof(&mut upstream, client_stream, VOLATILE_BODY_MAX)
+                .await
+                .map_err(|err| {
+                    SpliceProxyError::AfterHeaderClient(err, "simple-proxy body until EOF")
+                })?;
+        body_prefix.len() as u64 + helper_bytes
+    };
+
+    let t_done = coarsetime::Instant::now();
+    let in_time = request_received_at.elapsed();
+    info!(
+        "Simple proxy: passed through {upstream_path} from host {host_authority} for client {client} in {} ({}, {})",
+        HumanFmt::Time(in_time.into()),
+        rate_log::upstream_segment(forwarded, t_done.duration_since(t_req_sent)),
+        rate_log::client_segment(forwarded, t_done.duration_since(t_client_first)),
+    );
 
     metrics::SERVED_PASSTHROUGH.increment();
     metrics::SERVED_TOTAL.increment();

--- a/src/task_cleanup.rs
+++ b/src/task_cleanup.rs
@@ -636,6 +636,7 @@ where
 
         let conn_details = ConnectionDetails {
             client: ClientInfo::new_cleanup(),
+            request_received_at: Instant::now(),
             mirror: mirror.clone(),
             aliased_host: None,
             debname: debname_for(pkgfmt),


### PR DESCRIPTION
Widen scope to all four download/serve messages (splice streaming, volatile-buffered splice, hyper download, hyper serve); the `in` figure now spans the full proxy time from request parse; upstream rate shown only when the upstream transferred body bytes.

The splice-proxy success log's single ambiguous `rate=` is split into separate, labelled upstream and client rates, formatted through the shared `rate_log` module so the output stays identical across the hyper, sendfile and splice backends.

Late-joiner serve, disconnect and failure logs keep the "joining client" wording, on both the sendfile and channel delivery paths.