### PR TITLE
Verify downloaded content against repository metadata before caching

### DIFF
--- a/debian/apt-cacher-rs.conf
+++ b/debian/apt-cacher-rs.conf
@@ -144,3 +144,12 @@
 # When disabled, diff requests are proxied to the upstream mirror but not cached
 # (while full resources are always cached).
 #reject_pdiff_requests = true
+
+# Whether to verify cached content against the repository's own metadata
+# (by-hash digests, Packages checksums, Release checksums) before committing
+# a download to the cache. Defence in depth; APT's GPG check remains the
+# root of trust.
+#verify_checksums = true
+
+# Upper bound (entries) on the in-memory checksum registry.
+#verify_checksums_max_entries = 500000

--- a/src/active_downloads.rs
+++ b/src/active_downloads.rs
@@ -95,9 +95,22 @@ pub(crate) enum ActiveDownloadStatus {
         rx: tokio::sync::watch::Receiver<()>,
         meta: Arc<UpstreamMetadata>,
     },
+    /// All upstream bytes have been written to `path` (the partial / temp
+    /// file) but the file is still being hashed and renamed by
+    /// `RenameBarrier::commit` on a blocking thread. Readers that observe
+    /// this state can treat the file as a complete, drainable copy of the
+    /// resource: existing late-joiner file handles remain valid across the
+    /// upcoming rename (Linux keeps the inode open). The watch sender has
+    /// already been dropped by `begin_rename`, so this is the variant
+    /// late-joiners see after `RecvError` instead of a stale `Download`.
+    Verifying {
+        path: PathBuf,
+        content_length: ContentLength,
+        meta: Arc<UpstreamMetadata>,
+    },
     /// Rename-completed (or revalidation-confirmed) cached file.
     /// `meta` is `Some` when the values came from a fresh upstream
-    /// response (`RenameBarrier::release`); `None` when the entry was
+    /// response (`RenameBarrier::commit`); `None` when the entry was
     /// produced by `InitBarrier::finished` (e.g. volatile-revalidation
     /// 304) — in that case readers fall through to the post-flight
     /// [`crate::cache_metadata`] cache, which lazy-loads from xattrs.
@@ -400,14 +413,26 @@ impl ActiveDownloads {
             let mut sum = 0;
 
             for entry in self.inner.read().values() {
-                let d = entry.status.blocking_read();
-                if let ActiveDownloadStatus::Download {
-                    path: _,
-                    content_length,
-                    rx: _,
-                    meta: _,
-                } = &*d
-                {
+                let content_length = {
+                    let d = entry.status.blocking_read();
+                    match &*d {
+                        ActiveDownloadStatus::Download {
+                            path: _,
+                            content_length,
+                            rx: _,
+                            meta: _,
+                        }
+                        | ActiveDownloadStatus::Verifying {
+                            path: _,
+                            content_length,
+                            meta: _,
+                        } => Some(*content_length),
+                        ActiveDownloadStatus::Init(_)
+                        | ActiveDownloadStatus::Finished { .. }
+                        | ActiveDownloadStatus::Aborted(_) => None,
+                    }
+                };
+                if let Some(content_length) = content_length {
                     sum += content_length.upper().get();
                 }
             }
@@ -426,6 +451,7 @@ impl ActiveDownloads {
                 match &*d {
                     ActiveDownloadStatus::Init(_)
                     | ActiveDownloadStatus::Download { .. }
+                    | ActiveDownloadStatus::Verifying { .. }
                     | ActiveDownloadStatus::Aborted(_) => {
                         count += 1;
                     }

--- a/src/cache_layout.rs
+++ b/src/cache_layout.rs
@@ -134,6 +134,40 @@ pub(crate) enum CachedFlavor {
     Volatile,
 }
 
+/// Owned discriminator for the [`crate::deb_mirror::ResourceFile`] variant a
+/// request classified to.  [`RequestClass`] flattens a resource into
+/// `(cached_flavor, layout)`, which cannot tell `Packages` apart from other
+/// `Dists`/`Volatile` metadata; integrity needs the precise kind both to pick
+/// a verification strategy and to decide whether to ingest the file as an
+/// index.  Populated by [`classify_request`]'s exhaustive match, so a new
+/// `ResourceFile` variant compile-errors the classifier (the existing safety
+/// net) and forces a decision here too.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ResourceKind {
+    /// Structured `pool/...` `.deb`/`.udeb`/`.ddeb`.
+    Pool,
+    /// Structured `dists/.../Release` / `InRelease` / `Release.gpg`.
+    Release,
+    /// Structured per-component `Release`.
+    ComponentRelease,
+    /// Structured `dists/.../binary-*/Packages*`.
+    Packages,
+    /// Structured `dists/.../source/Sources*`.
+    Sources,
+    /// `dists/.../i18n/Translation-*`.
+    Translation,
+    /// `dists/.../dep11/icons-*` / component metadata.
+    Icon,
+    /// Structured content-addressed `dists/.../by-hash/SHA*/<hex>`.
+    ByHash,
+    /// Flat-repository metadata file (`Packages*`, `Release`, ...).
+    FlatMetadata,
+    /// Flat-repository `.deb` pool file.
+    FlatPool,
+    /// Flat-repository content-addressed `by-hash/SHA*/<hex>`.
+    FlatByHash,
+}
+
 /// On-disk cache layout for a request.  Doubles as the discriminator on
 /// the `(mirror, debname)` keys for [`crate::active_downloads`] and
 /// [`crate::cache_metadata`] — without it, a flat-pool file and a
@@ -204,6 +238,7 @@ pub(crate) struct ConnectionDetails {
     pub(crate) debname: String,
     pub(crate) cached_flavor: CachedFlavor,
     pub(crate) layout: CacheLayout,
+    pub(crate) resource_kind: ResourceKind,
 }
 
 impl ConnectionDetails {
@@ -325,6 +360,7 @@ pub(crate) struct RequestClass {
     pub(crate) debname: String,
     pub(crate) cached_flavor: CachedFlavor,
     pub(crate) layout: CacheLayout,
+    pub(crate) resource_kind: ResourceKind,
     pub(crate) origin_fields: Option<OriginFields>,
 }
 
@@ -402,6 +438,7 @@ pub(crate) fn classify_request<'a>(
                 debname: filename.into_owned(),
                 cached_flavor: CachedFlavor::Permanent,
                 layout: CacheLayout::StructuredPool,
+                resource_kind: ResourceKind::Pool,
                 origin_fields: None,
             })
         }
@@ -423,6 +460,7 @@ pub(crate) fn classify_request<'a>(
                 debname: format!("{distribution}_{filename}"),
                 cached_flavor: CachedFlavor::Volatile,
                 layout: CacheLayout::Dists,
+                resource_kind: ResourceKind::Release,
                 origin_fields: None,
             })
         }
@@ -442,22 +480,11 @@ pub(crate) fn classify_request<'a>(
                 debname: filename.into_owned(),
                 cached_flavor: CachedFlavor::Permanent,
                 layout: CacheLayout::DistsByHash,
+                resource_kind: ResourceKind::ByHash,
                 origin_fields: None,
             })
         }
         ResourceFile::Icon {
-            mirror_path,
-            distribution,
-            component,
-            filename,
-        }
-        | ResourceFile::Sources {
-            mirror_path,
-            distribution,
-            component,
-            filename,
-        }
-        | ResourceFile::Translation {
             mirror_path,
             distribution,
             component,
@@ -477,6 +504,55 @@ pub(crate) fn classify_request<'a>(
                 debname: format!("{distribution}_{component}_{filename}"),
                 cached_flavor: CachedFlavor::Volatile,
                 layout: CacheLayout::Dists,
+                resource_kind: ResourceKind::Icon,
+                origin_fields: None,
+            })
+        }
+        ResourceFile::Sources {
+            mirror_path,
+            distribution,
+            component,
+            filename,
+        } => {
+            let mirror_path = decode_validate(mirror_path, ValidateKind::MirrorPath)?;
+            let distribution = decode_validate(distribution, ValidateKind::Distribution)?;
+            let component = decode_validate(component, ValidateKind::Component)?;
+            let filename = decode_validate(filename, ValidateKind::Filename)?;
+
+            trace!(
+                "Decoded mirror path: `{mirror_path}`; Decoded distribution: `{distribution}`; Decoded component: `{component}`; Decoded filename: `{filename}` (client {client})"
+            );
+
+            Ok(RequestClass {
+                mirror_path: mirror_path.into_owned(),
+                debname: format!("{distribution}_{component}_{filename}"),
+                cached_flavor: CachedFlavor::Volatile,
+                layout: CacheLayout::Dists,
+                resource_kind: ResourceKind::Sources,
+                origin_fields: None,
+            })
+        }
+        ResourceFile::Translation {
+            mirror_path,
+            distribution,
+            component,
+            filename,
+        } => {
+            let mirror_path = decode_validate(mirror_path, ValidateKind::MirrorPath)?;
+            let distribution = decode_validate(distribution, ValidateKind::Distribution)?;
+            let component = decode_validate(component, ValidateKind::Component)?;
+            let filename = decode_validate(filename, ValidateKind::Filename)?;
+
+            trace!(
+                "Decoded mirror path: `{mirror_path}`; Decoded distribution: `{distribution}`; Decoded component: `{component}`; Decoded filename: `{filename}` (client {client})"
+            );
+
+            Ok(RequestClass {
+                mirror_path: mirror_path.into_owned(),
+                debname: format!("{distribution}_{component}_{filename}"),
+                cached_flavor: CachedFlavor::Volatile,
+                layout: CacheLayout::Dists,
+                resource_kind: ResourceKind::Translation,
                 origin_fields: None,
             })
         }
@@ -505,6 +581,7 @@ pub(crate) fn classify_request<'a>(
                 debname: format!("{distribution}_{component}_{architecture}_{filename}"),
                 cached_flavor: CachedFlavor::Volatile,
                 layout: CacheLayout::Dists,
+                resource_kind: ResourceKind::ComponentRelease,
                 origin_fields: None,
             })
         }
@@ -542,6 +619,7 @@ pub(crate) fn classify_request<'a>(
                 debname: format!("{distribution}_{component}_{architecture}_{filename}"),
                 cached_flavor: CachedFlavor::Volatile,
                 layout: CacheLayout::Dists,
+                resource_kind: ResourceKind::Packages,
                 origin_fields,
             })
         }
@@ -557,8 +635,12 @@ pub(crate) fn classify_request<'a>(
                 "Decoded flat mirror path: `{mirror_path}`; Decoded flat filename: `{filename}` (kind: {kind:?}; client {client})"
             );
 
-            let (cached_flavor, layout) = match kind {
-                FlatKind::Metadata => (CachedFlavor::Volatile, CacheLayout::Flat),
+            let (cached_flavor, layout, resource_kind) = match kind {
+                FlatKind::Metadata => (
+                    CachedFlavor::Volatile,
+                    CacheLayout::Flat,
+                    ResourceKind::FlatMetadata,
+                ),
                 FlatKind::Pool => {
                     // `parse_request_path` runs `is_flat_deb_filename` on
                     // the *raw* URL segment, so a percent-encoded
@@ -570,9 +652,17 @@ pub(crate) fn classify_request<'a>(
                     if !is_flat_deb_filename(&filename) {
                         return Err(ClassifyError::NonDebPool { filename });
                     }
-                    (CachedFlavor::Permanent, CacheLayout::Flat)
+                    (
+                        CachedFlavor::Permanent,
+                        CacheLayout::Flat,
+                        ResourceKind::FlatPool,
+                    )
                 }
-                FlatKind::ByHash => (CachedFlavor::Permanent, CacheLayout::FlatByHash),
+                FlatKind::ByHash => (
+                    CachedFlavor::Permanent,
+                    CacheLayout::FlatByHash,
+                    ResourceKind::FlatByHash,
+                ),
             };
 
             Ok(RequestClass {
@@ -580,6 +670,7 @@ pub(crate) fn classify_request<'a>(
                 debname: filename.into_owned(),
                 cached_flavor,
                 layout,
+                resource_kind,
                 origin_fields: None,
             })
         }
@@ -811,6 +902,7 @@ mod tests {
         assert_eq!(class.debname, "php-zts-cli_8.5.7-1_amd64.deb");
         assert_eq!(class.cached_flavor, CachedFlavor::Permanent);
         assert_eq!(class.layout, CacheLayout::Flat);
+        assert_eq!(class.resource_kind, ResourceKind::FlatPool);
     }
 
     #[test]
@@ -874,5 +966,56 @@ mod tests {
                 decoded,
             }) if decoded == "../escape"
         ));
+    }
+
+    #[test]
+    fn classify_sets_resource_kind() {
+        let pool = ResourceFile::Pool {
+            mirror_path: "debian",
+            filename: "foo_1.0_amd64.deb",
+        };
+        assert_eq!(
+            classify_request(&pool, &fake_client())
+                .unwrap()
+                .resource_kind,
+            ResourceKind::Pool
+        );
+
+        let pkgs = ResourceFile::Packages {
+            mirror_path: "debian",
+            distribution: "sid",
+            component: "main",
+            architecture: "binary-amd64",
+            filename: "Packages.xz",
+        };
+        assert_eq!(
+            classify_request(&pkgs, &fake_client())
+                .unwrap()
+                .resource_kind,
+            ResourceKind::Packages
+        );
+
+        let byhash = ResourceFile::ByHash {
+            mirror_path: "debian",
+            filename: "4f8878062744fae5ff91f1ad0f3efecc760514381bf029d06bdf7023cfc379ba",
+        };
+        assert_eq!(
+            classify_request(&byhash, &fake_client())
+                .unwrap()
+                .resource_kind,
+            ResourceKind::ByHash
+        );
+
+        let rel = ResourceFile::Release {
+            mirror_path: "debian",
+            distribution: "sid",
+            filename: "Release",
+        };
+        assert_eq!(
+            classify_request(&rel, &fake_client())
+                .unwrap()
+                .resource_kind,
+            ResourceKind::Release
+        );
     }
 }

--- a/src/cache_metadata.rs
+++ b/src/cache_metadata.rs
@@ -14,11 +14,11 @@
 //!   [`crate::ActiveDownloadStatus::Download`] and on `Finished { meta:
 //!   Some(_) }`; late-joiners read those directly. `Finished { meta:
 //!   None }` (volatile-304 in `InitBarrier::finished`, error fallback
-//!   in `RenameBarrier::release`) falls through to
+//!   in `RenameBarrier::commit`) falls through to
 //!   [`CacheMetadataStore::resolve`].
 //! - **Post-flight (rename complete, active-downloads entry removed)** is
 //!   what this cache covers. The transition from in-flight to post-flight
-//!   happens inside `RenameBarrier::release`, which calls
+//!   happens inside `RenameBarrier::commit`, which calls
 //!   [`CacheMetadataStore::set`] (via `cache_metadata::store().set(...)`)
 //!   *before* removing the active-downloads entry — so a worker that
 //!   misses the entry always finds the cache populated.

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,8 @@ const DEFAULT_MMAP_THRESHOLD: NonZero<u64> = nonzero!(1024 * 1024); // 1MiB
 const DEFAULT_MAX_OBJECT_SIZE: Option<NonZero<u64>> = Some(nonzero!(2 * 1024 * 1024 * 1024));
 const DEFAULT_UPSTREAM_TCP_NODELAY: bool = true;
 const DEFAULT_REJECT_PDIFF_REQUESTS: bool = true;
+const DEFAULT_VERIFY_CHECKSUMS: bool = true;
+const DEFAULT_VERIFY_CHECKSUMS_MAX_ENTRIES: NonZero<usize> = nonzero!(500_000);
 const DEFAULT_EXPERIMENTAL_PARALLEL_HACK_ENABLED: bool = false;
 const DEFAULT_EXPERIMENTAL_PARALLEL_HACK_MAXPARALLEL: Option<NonZero<usize>> = Some(nonzero!(3));
 const DEFAULT_EXPERIMENTAL_PARALLEL_HACK_STATUSCODE: StatusCode = StatusCode::TOO_MANY_REQUESTS;
@@ -805,6 +807,23 @@ pub(crate) struct Config {
     #[serde(default = "default_reject_pdiff_requests")]
     pub(crate) reject_pdiff_requests: bool,
 
+    /// Whether to verify the integrity of cached content against the
+    /// repository's own metadata (by-hash digests, `Packages` checksums,
+    /// `Release` checksums) before committing a download to the cache.
+    /// Defence in depth: APT's client-side GPG check remains the root of
+    /// trust. Verification reads each verifiable file back once before
+    /// `rename`; the cost is one extra (page-cache-hot) full read.
+    #[serde(default = "default_verify_checksums")]
+    pub(crate) verify_checksums: bool,
+
+    /// Upper bound on the in-memory checksum registry (entries). The registry
+    /// maps `(host, mirror_path, resource key)` to an expected digest, populated
+    /// by parsing index files as they flow through. At the cap, the oldest
+    /// entries are evicted in bulk. One full Debian `main`/amd64 `Packages` is
+    /// ~64k entries.
+    #[serde(default = "default_verify_checksums_max_entries")]
+    pub(crate) verify_checksums_max_entries: NonZero<usize>,
+
     #[serde(default = "default_experimental_parallel_hack_enabled")]
     pub(crate) experimental_parallel_hack_enabled: bool,
 
@@ -1063,6 +1082,14 @@ const fn default_usage_retention_days() -> Option<NonZero<u64>> {
 
 const fn default_reject_pdiff_requests() -> bool {
     DEFAULT_REJECT_PDIFF_REQUESTS
+}
+
+const fn default_verify_checksums() -> bool {
+    DEFAULT_VERIFY_CHECKSUMS
+}
+
+const fn default_verify_checksums_max_entries() -> NonZero<usize> {
+    DEFAULT_VERIFY_CHECKSUMS_MAX_ENTRIES
 }
 
 const fn default_logstore_capacity() -> NonZero<usize> {
@@ -1667,6 +1694,13 @@ impl Config {
             ));
         }
 
+        if self.verify_checksums && self.verify_checksums_max_entries.get() < 10_000 {
+            warnings.push(format!(
+                "verify_checksums_max_entries ({}) is very low; checksum verification coverage of .deb files will be poor",
+                self.verify_checksums_max_entries
+            ));
+        }
+
         if self.cache_directory.as_os_str().is_empty() {
             bail!("Invalid cache_directory value: must not be empty");
         }
@@ -2033,5 +2067,18 @@ mod test {
         assert_eq!(client.format_cache_dir(port).as_ref(), "example.test:8080");
         assert_eq!(cache.format_cache_dir(port).as_ref(), "example.test:8080");
         assert_eq!(client.format_authority(port).as_ref(), "example.test:8080");
+    }
+
+    #[test]
+    fn verify_checksums_defaults_on() {
+        let cfg: Config = toml::from_str("").expect("empty config parses");
+        assert!(cfg.verify_checksums);
+        assert_eq!(cfg.verify_checksums_max_entries.get(), 500_000);
+    }
+
+    #[test]
+    fn verify_checksums_can_be_disabled() {
+        let cfg: Config = toml::from_str("verify_checksums = false").expect("config parses");
+        assert!(!cfg.verify_checksums);
     }
 }

--- a/src/guards.rs
+++ b/src/guards.rs
@@ -10,6 +10,7 @@ use crate::{
     cache_quota::QuotaReservation,
     config::CacheHost,
     deb_mirror::Mirror,
+    integrity::{self, CommitError, RenamePlan},
     metrics,
 };
 #[cfg(feature = "splice")]
@@ -218,18 +219,53 @@ impl DownloadBarrier {
     pub(crate) async fn begin_rename(mut self) -> RenameBarrier {
         let mut data = self.data.take().expect("every sink consumes the instance");
 
-        // Ordering matters: flush the final ping, drop `tx`, then take the status
-        // write lock. The watch channel retains the last sent value after sender drop,
-        // so a racing receiver either wakes from `.changed()` Ok (saw the ping) or
-        // RecvError then observes Finished after `RenameBarrier::release`.
+        // Ordering matters: flush the final ping, flip `Download -> Verifying`
+        // under the status write lock, release the lock, then drop `tx`.
+        //
+        // The flip is what closes the late-joiner race: any reader that wakes
+        // from `receiver.changed().await` with `RecvError` (sender dropped)
+        // re-reads `status` and is guaranteed to see `Verifying`, `Finished`,
+        // or `Aborted` — never a stale `Download`. The reader paths in
+        // `hyper_conn.rs` and `sendfile_conn.rs` treat `Verifying` as "all
+        // bytes are on disk; drain the open file handle" rather than as an
+        // error.
+        //
+        // The write lock is only held for the brief variant swap, NOT for the
+        // subsequent SHA-256 hashing in `RenameBarrier::commit` (which can
+        // take hundreds of ms for a large `.deb`). Late-joiner readers are
+        // therefore not stalled during verification.
         data.flush_batched_ping();
+        {
+            let mut lock = data.status.write().await;
+            let prev = std::mem::replace(
+                &mut *lock,
+                ActiveDownloadStatus::Aborted(AbortReason::AlreadyLoggedJustFail),
+            );
+            *lock = match prev {
+                ActiveDownloadStatus::Download {
+                    path,
+                    content_length,
+                    rx: _,
+                    meta,
+                } => ActiveDownloadStatus::Verifying {
+                    path,
+                    content_length,
+                    meta,
+                },
+                other @ (ActiveDownloadStatus::Init(_)
+                | ActiveDownloadStatus::Verifying { .. }
+                | ActiveDownloadStatus::Finished { .. }
+                | ActiveDownloadStatus::Aborted(_)) => {
+                    error!("begin_rename reached with non-Download status: {other:?}");
+                    other
+                }
+            };
+        }
         drop(data.tx);
-
-        let lock = data.status.write_owned().await;
 
         RenameBarrier {
             data: Some(RenameBarrierData {
-                lock,
+                status: data.status,
                 active_downloads: data.active_downloads,
                 mirror: data.mirror,
                 debname: data.debname,
@@ -323,7 +359,7 @@ impl Drop for DownloadBarrier {
 }
 
 struct RenameBarrierData {
-    lock: tokio::sync::OwnedRwLockWriteGuard<ActiveDownloadStatus>,
+    status: Arc<tokio::sync::RwLock<ActiveDownloadStatus>>,
     active_downloads: ActiveDownloads,
     mirror: Mirror,
     debname: String,
@@ -337,54 +373,69 @@ pub(crate) struct RenameBarrier {
 }
 
 impl RenameBarrier {
-    /// Transition the barrier to `Finished`, publish the upstream metadata
-    /// to the post-flight [`cache_metadata`] cache, and clear the
+    /// Verify the finished temp file, rename it into the cache, transition the
+    /// barrier to `Finished`, publish upstream metadata, and clear the
     /// active-downloads entry.
     ///
-    /// Ordering matters: the cache is populated **before** the entry
-    /// is removed, so workers that miss the entry always find it
-    /// primed.  Workers that still see the entry observe `Finished
-    /// { meta: Some(_) }` and read from status.  The non-`Download`
-    /// fallback below is a logic-bug path: logs, sets `meta: None`,
-    /// skips the cache publish; observers fall through to
-    /// `cache_metadata::resolve` like `InitBarrier::finished`.
-    pub(crate) fn release(mut self, path: PathBuf, bytes_received: u64) {
-        let mut data = self.data.take().expect("every sink consumes the instance");
+    /// Verification is delegated to `integrity::verify_and_rename`; this is the
+    /// **only** way to finish a `RenameBarrier`, so no download backend can
+    /// commit a download without it. On any `CommitError` the barrier is
+    /// dropped (its `Drop` runs the abort / signal-waiters path, exactly as a
+    /// failed rename does today) and the error is returned to the caller.
+    ///
+    /// Lock ordering: `verify_and_rename` runs *before* the status write lock
+    /// is acquired, so late-joiner readers (`status.read().await`) can proceed
+    /// concurrently while the temp file is being SHA-256-hashed on a blocking
+    /// thread. The lock is only held for the brief `Verifying -> Finished`
+    /// status flip after verification succeeds. The preceding `Download ->
+    /// Verifying` flip happens in `DownloadBarrier::begin_rename`.
+    ///
+    /// Cancellation window: if the `commit` future is dropped between the
+    /// `tokio::fs::rename` completing and the status-write lock being
+    /// acquired, the renamed file is already in the cache but the
+    /// `Verifying -> Finished` flip never runs; `Drop for RenameBarrier`
+    /// then flips status to `Aborted` and removes the active-downloads
+    /// entry. The xattr-backed metadata persists on disk regardless, so
+    /// post-flight readers lazy-load `ETag` / `Last-Modified` via
+    /// `cache_metadata::store().resolve(...)` instead of from the in-process
+    /// Arc -- benign for correctness, just slightly slower for the first
+    /// read after cancellation.
+    pub(crate) async fn commit(mut self, plan: RenamePlan) -> Result<(), CommitError> {
+        integrity::verify_and_rename(&plan).await?;
+
+        // Verified and renamed. Finalise quota outside the lock, then take the
+        // write lock briefly for the `Verifying -> Finished` status flip.
+        let data = self.data.take().expect("every sink consumes the instance");
 
         if let Some(reservation) = data.quota_reservation {
-            reservation.finalize(bytes_received);
+            reservation.finalize(plan.bytes_received);
         }
 
-        // Carry the in-flight metadata over to the post-flight cache and
-        // the `Finished` status before we tear the active-downloads entry
-        // down.  The barrier reached this point via `DownloadBarrier`
-        // (which set the status to `Download { meta }`); any other shape
-        // is a logic bug — log it, fall back to no metadata, and proceed
-        // with the status / cache transitions so the active-downloads
-        // entry doesn't leak.
-        let meta_for_status: Option<Arc<UpstreamMetadata>> = match &*data.lock {
-            ActiveDownloadStatus::Download {
-                path: _,
-                content_length: _,
-                rx: _,
-                meta,
-            } => Some(Arc::clone(meta)),
-            ActiveDownloadStatus::Init(_)
-            | ActiveDownloadStatus::Finished { .. }
-            | ActiveDownloadStatus::Aborted(_) => {
-                error!(
-                    "RenameBarrier::release reached with non-Download status: {:?}",
-                    *data.lock
-                );
-                None
-            }
+        let meta_for_status: Option<Arc<UpstreamMetadata>> = {
+            let mut lock = data.status.write().await;
+            let meta = match &*lock {
+                ActiveDownloadStatus::Verifying {
+                    path: _,
+                    content_length: _,
+                    meta,
+                } => Some(Arc::clone(meta)),
+                ActiveDownloadStatus::Init(_)
+                | ActiveDownloadStatus::Download { .. }
+                | ActiveDownloadStatus::Finished { .. }
+                | ActiveDownloadStatus::Aborted(_) => {
+                    error!(
+                        "RenameBarrier::commit reached with non-Verifying status: {:?}",
+                        *lock
+                    );
+                    None
+                }
+            };
+            *lock = ActiveDownloadStatus::Finished {
+                path: plan.dest_path,
+                meta: meta.clone(),
+            };
+            meta
         };
-
-        *data.lock = ActiveDownloadStatus::Finished {
-            path,
-            meta: meta_for_status.clone(),
-        };
-        drop(data.lock);
 
         if let Some(meta) = meta_for_status {
             cache_metadata::store().set(
@@ -394,18 +445,24 @@ impl RenameBarrier {
         }
         data.active_downloads
             .remove(&data.mirror, &data.debname, data.layout);
+
+        Ok(())
     }
 }
 
 impl Drop for RenameBarrier {
     fn drop(&mut self) {
-        if let Some(mut data) = self.data.take() {
-            *data.lock = ActiveDownloadStatus::Aborted(AbortReason::AlreadyLoggedJustFail);
-            metrics::DOWNLOADS_ABORTED.increment();
-            drop(data.lock);
-
-            data.active_downloads
-                .remove(&data.mirror, &data.debname, data.layout);
+        if let Some(data) = self.data.take() {
+            // Mirrors `Drop for DownloadBarrier`: the status handle is now an
+            // `Arc<RwLock<...>>` (not an `OwnedRwLockWriteGuard`), so the
+            // write lock has to be acquired synchronously here.
+            tokio::task::block_in_place(|| {
+                *data.status.blocking_write() =
+                    ActiveDownloadStatus::Aborted(AbortReason::AlreadyLoggedJustFail);
+                metrics::DOWNLOADS_ABORTED.increment();
+                data.active_downloads
+                    .remove(&data.mirror, &data.debname, data.layout);
+            });
         }
     }
 }

--- a/src/hyper_conn.rs
+++ b/src/hyper_conn.rs
@@ -50,7 +50,7 @@ use crate::{
     http_last_modified::write_last_modified,
     http_range::{self, HttpDate, ParsedRange, format_http_date, http_parse_range},
     humanfmt::HumanFmt,
-    limits, metrics,
+    integrity, limits, metrics,
     permitted_host_cache::{authorize_cache_access, is_host_allowed_cached},
     precise_instant::PreciseInstant,
     quick_response,
@@ -908,7 +908,11 @@ async fn serve_unfinished_file(
                 /* sender closed, either download finished or aborted */
                 let st = status.read().await;
                 let _: Never = match *st {
-                    ActiveDownloadStatus::Finished { .. } => {
+                    // Verifying: writer has written all bytes and is hashing on
+                    // a blocking thread. The open file handle stays valid
+                    // across the upcoming rename, so drain like Finished.
+                    ActiveDownloadStatus::Finished { .. }
+                    | ActiveDownloadStatus::Verifying { .. } => {
                         drop(st);
                         finished = true;
                         continue;
@@ -1543,6 +1547,61 @@ async fn serve_downloading_file(
                 )
                 .await;
             }
+            ActiveDownloadStatus::Verifying {
+                path,
+                content_length: _,
+                meta,
+            } => {
+                // Writer has finished writing all bytes; the file is being
+                // hashed and will be renamed to its dest path. Open the
+                // partial path now — the inode stays valid across the
+                // upcoming rename. On the rare ENOENT race (open after the
+                // rename completes but before the status flip lands), re-loop
+                // and pick up the Finished state with the new path.
+                let path_clone = path.clone();
+                let prefetched_upstream_metadata = if let Some(meta) = prefetched_upstream_metadata
+                {
+                    Some(UpstreamMetadataView::Borrowed(meta))
+                } else {
+                    Some(UpstreamMetadataView::Arc(Arc::clone(meta)))
+                };
+                drop(st);
+                let file = match tokio::fs::File::options()
+                    .read(true)
+                    .custom_flags(nix::libc::O_NOFOLLOW)
+                    .open(&path_clone)
+                    .await
+                {
+                    Ok(f) => f,
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        // Lost the rename race; re-read status.
+                        continue;
+                    }
+                    Err(err) => {
+                        metrics::CACHE_IO_FAILURE.increment();
+                        error!(
+                            "Failed to open verifying file `{}`:  {}",
+                            path_clone.display(),
+                            ErrorReport(&err)
+                        );
+                        return quick_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "Cache Access Failure",
+                        );
+                    }
+                };
+                drop(status);
+
+                return serve_cached_file(
+                    conn_details,
+                    &req,
+                    file,
+                    path_clone,
+                    prefetched_upstream_metadata.as_deref(),
+                    None,
+                )
+                .await;
+            }
             ActiveDownloadStatus::Download {
                 path,
                 content_length,
@@ -1711,6 +1770,10 @@ async fn serve_volatile_file(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "has only one caller and is task entrypoint"
+)]
 async fn download_file(
     conn_details: &ConnectionDetails,
     warn_on_override: bool,
@@ -1719,6 +1782,7 @@ async fn download_file(
     mut dbarrier: DownloadBarrier,
     resume_offset: u64,
     request_sent: PreciseInstant,
+    raw_uri_path: String,
 ) {
     let config = global_config();
 
@@ -1915,25 +1979,36 @@ async fn download_file(
             }
         }
 
-        match tokio::fs::rename(&outpath, &dest_file_path).await {
+        let total_bytes = resume_offset + bytes;
+        let plan = integrity::RenamePlan {
+            temp_path: outpath.to_path_buf(),
+            dest_path: dest_file_path.clone(),
+            bytes_received: total_bytes,
+            resource_kind: conn_details.resource_kind,
+            debname: conn_details.debname.clone(),
+            host: conn_details.mirror.host().to_string(),
+            mirror_path: conn_details.mirror.path().to_owned(),
+            raw_uri_path: raw_uri_path.clone(),
+        };
+        match rbarrier.commit(plan).await {
             Ok(()) => {
-                // Defuse the TempPath - the file has been successfully renamed
+                // The file was verified and renamed; defuse the temp guard.
                 TempPath::defuse(outpath);
-
-                let total_bytes = resume_offset + bytes;
-                rbarrier.release(dest_file_path, total_bytes);
             }
             Err(err) => {
-                drop(rbarrier);
-
-                metrics::CACHE_IO_FAILURE.increment();
-                error!(
-                    "Failed to rename file `{}` to `{}`:  {err}",
-                    outpath.display(),
-                    dest_file_path.display()
-                );
-                // The scopeguard will remove the temp file on drop
-
+                // commit() already dropped the barrier (abort path) and logged
+                // mismatch / verify-IO; rename failures are logged here. The
+                // TempPath guard removes the temp file on drop. The client was
+                // already served from the live stream.
+                if let integrity::CommitError::Rename(io_err) = &err {
+                    metrics::CACHE_IO_FAILURE.increment();
+                    error!(
+                        "Failed to rename file `{}` to `{}`:  {}",
+                        outpath.display(),
+                        dest_file_path.display(),
+                        ErrorReport(io_err)
+                    );
+                }
                 return;
             }
         }
@@ -2834,6 +2909,7 @@ async fn serve_new_file(
 
     {
         let cd = conn_details.clone();
+        let raw_uri_path = req.uri().path().to_owned();
         tokio::task::spawn(async move {
             download_file(
                 &cd,
@@ -2843,6 +2919,7 @@ async fn serve_new_file(
                 dbarrier,
                 resume_offset,
                 upstream_request_sent,
+                raw_uri_path,
             )
             .await;
         });
@@ -3345,6 +3422,7 @@ async fn pre_process_client_request(
                     debname: plan.debname,
                     cached_flavor: plan.cached_flavor,
                     layout: plan.layout,
+                    resource_kind: plan.resource_kind,
                 };
                 return process_cache_request(conn_details, req, appstate).await;
             }

--- a/src/index_parser.rs
+++ b/src/index_parser.rs
@@ -2,9 +2,9 @@
 //! field, hex-encoded `SHA256:` / `SHA512:` digests, and the small helpers
 //! that derive cache lookup keys from a stanza's relative path.
 //!
-//! Used by `task_cleanup`'s 24h sweep (and its tests). The cold path is
-//! currently the only consumer; the helpers stay free of hot-path-specific
-//! coupling so they can be reused if a future call site needs them.
+//! Used by `integrity.rs` (post-commit registry ingest/verify) and
+//! `task_cleanup`'s 24h sweep (and its tests). Cold-path only; the helpers
+//! stay free of hot-path-specific coupling.
 
 use std::path::Path;
 
@@ -167,6 +167,110 @@ impl Stanza {
     }
 }
 
+/// Decode a `by-hash` URL's digest filename against the algorithm taken from
+/// the URL's `<algo>` path segment (see `integrity::byhash_algo_from_uri_path`).
+///
+/// A `/by-hash/SHA256/<hex>` (or `/SHA512/<hex>`) URL embeds the digest in the
+/// path component, so the filename *is* the expected digest -- but the
+/// authoritative algorithm is the `<algo>` segment, not the digest length. The
+/// hex length must match `algo` (64 for SHA256, 128 for SHA512); a length/algo
+/// mismatch or non-hex input returns `None`, so verification treats the
+/// resource as unverifiable rather than hashing with the wrong algorithm.
+pub(crate) fn byhash_digest_for_algo(algo: HashAlgo, filename: &str) -> Option<Vec<u8>> {
+    match algo {
+        HashAlgo::Sha256 => hex_decode_exact::<32>(filename).map(|d| d.to_vec()),
+        HashAlgo::Sha512 => hex_decode_exact::<64>(filename).map(|d| d.to_vec()),
+    }
+}
+
+/// Discriminator for `Packages`/`Filename` parsing rules: structured
+/// (pool-based) repositories versus flat-repo layouts. Replaces the
+/// previous `is_flat: bool` parameter so the call sites self-document and
+/// no impossible "neither" state can be constructed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IndexFormat {
+    Structured,
+    Flat,
+}
+
+/// Map a `Packages` stanza `Filename:` value to the registry key used to look
+/// it up at `.deb` download time.
+///
+/// - structured repos: the cache flattens `pool/.../<deb>` to the basename, so
+///   the key is the basename (`structured_lookup_key`).
+/// - flat repos: the URL path is the on-disk path verbatim, so the key is the
+///   validated relpath itself.
+///
+/// Returns `None` when the relpath fails `is_safe_filename_relpath`.
+pub(crate) fn registry_key_from_filename_field(
+    filename_field: &str,
+    format: IndexFormat,
+) -> Option<String> {
+    if !is_safe_filename_relpath(filename_field) {
+        return None;
+    }
+    match format {
+        IndexFormat::Flat => Some(filename_field.to_owned()),
+        IndexFormat::Structured => structured_lookup_key(filename_field).map(str::to_owned),
+    }
+}
+
+/// Iterate the `(repo-relative path, SHA256 digest)` entries from a Debian
+/// `Release` / `InRelease` file's `SHA256:` section.
+///
+/// Handles the `InRelease` clearsigned wrapper by stopping at the PGP
+/// signature boundary. Entry lines are indented with one or more spaces or
+/// tabs followed by `<hex> <size> <path>`; the section ends at the first
+/// non-indented line. Paths failing `is_safe_filename_relpath` are skipped.
+pub(crate) fn parse_release_checksums(
+    content: &str,
+) -> impl Iterator<Item = (String, [u8; 32])> + '_ {
+    let mut in_sha256_section = false;
+    content.lines().filter_map(move |line| {
+        if line.starts_with("-----BEGIN PGP SIGNATURE-----") {
+            in_sha256_section = false;
+            return None;
+        }
+        // A non-indented, non-empty line ends the current section. Section
+        // headers ("SHA256:", "MD5Sum:", ...) are themselves non-indented.
+        // Debian uses spaces but accept tabs too so non-canonical mirrors
+        // that emit `\t`-indented entries still ingest.
+        let indented = line.starts_with(' ') || line.starts_with('\t');
+        if !indented && !line.is_empty() {
+            in_sha256_section = line.trim_end() == "SHA256:";
+            return None;
+        }
+        if !in_sha256_section {
+            return None;
+        }
+        // Indented entry: " <hex> <size> <path>"
+        let mut parts = line.split_whitespace();
+        let hex = parts.next()?;
+        let _size = parts.next()?;
+        let path = parts.next()?;
+        // Debian repo paths do not contain spaces; if a 4th token exists the
+        // path had a space - reject.
+        if parts.next().is_some() {
+            return None;
+        }
+        let digest = hex_decode_exact::<32>(hex)?;
+        if !is_safe_filename_relpath(path) {
+            return None;
+        }
+        Some((path.to_owned(), digest))
+    })
+}
+
+/// Map a `.deb` download's request to the same registry key.
+///
+/// `debname` is `ConnectionDetails::debname` (already the basename for a
+/// structured pool file). For structured pool the key is `debname` directly.
+/// Flat-pool layer-B verification is deferred (see the plan's deferred list),
+/// so this is currently only used for the structured-pool path.
+pub(crate) fn registry_key_for_download(debname: &str) -> String {
+    debname.to_owned()
+}
+
 /// Hash the contents of an open file. Synchronous; blocks the current thread.
 pub(crate) fn hash_open_file<D: sha2::Digest>(
     file: &mut std::fs::File,
@@ -218,5 +322,136 @@ mod tests {
             s.chosen(),
             Some((HashAlgo::Sha256, [0x11u8; 32].as_slice()))
         );
+    }
+
+    #[test]
+    fn byhash_digest_sha256() {
+        let hex = "4f8878062744fae5ff91f1ad0f3efecc760514381bf029d06bdf7023cfc379ba";
+        let digest = byhash_digest_for_algo(HashAlgo::Sha256, hex).expect("valid sha256 hex");
+        assert_eq!(digest.len(), 32);
+        assert_eq!(hex_encode(&digest), hex);
+    }
+
+    #[test]
+    fn byhash_digest_sha512() {
+        let hex = &"a".repeat(128);
+        let digest = byhash_digest_for_algo(HashAlgo::Sha512, hex).expect("valid sha512 hex");
+        assert_eq!(digest.len(), 64);
+        assert_eq!(hex_encode(&digest), *hex);
+    }
+
+    #[test]
+    fn byhash_digest_rejects_bad_input() {
+        assert!(byhash_digest_for_algo(HashAlgo::Sha256, "").is_none());
+        assert!(byhash_digest_for_algo(HashAlgo::Sha256, "deadbeef").is_none()); // too short
+        assert!(byhash_digest_for_algo(HashAlgo::Sha256, &"z".repeat(64)).is_none()); // non-hex
+        // Length/algo mismatch: a 128-hex digest under a SHA256 URL segment (or
+        // a 64-hex one under SHA512) must be rejected, never hashed as the other
+        // algorithm.
+        assert!(byhash_digest_for_algo(HashAlgo::Sha256, &"a".repeat(128)).is_none());
+        assert!(byhash_digest_for_algo(HashAlgo::Sha512, &"a".repeat(64)).is_none());
+    }
+
+    #[test]
+    fn registry_key_for_structured_pool_uses_basename() {
+        assert_eq!(
+            registry_key_from_filename_field(
+                "pool/main/f/foo/foo_1.0_amd64.deb",
+                IndexFormat::Structured,
+            ),
+            Some("foo_1.0_amd64.deb".to_string())
+        );
+    }
+
+    #[test]
+    fn registry_key_for_flat_uses_relpath_verbatim() {
+        assert_eq!(
+            registry_key_from_filename_field("amd64/foo_1.0_amd64.deb", IndexFormat::Flat),
+            Some("amd64/foo_1.0_amd64.deb".to_string())
+        );
+    }
+
+    #[test]
+    fn registry_key_rejects_unsafe_relpath() {
+        assert_eq!(
+            registry_key_from_filename_field("../etc/passwd", IndexFormat::Structured),
+            None
+        );
+        assert_eq!(
+            registry_key_from_filename_field("", IndexFormat::Flat),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_release_detached() {
+        let release = "\
+Origin: Debian
+Suite: sid
+MD5Sum:
+ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1234 main/binary-amd64/Packages
+SHA256:
+ 1111111111111111111111111111111111111111111111111111111111111111 1234 main/binary-amd64/Packages
+ 2222222222222222222222222222222222222222222222222222222222222222 567 main/binary-amd64/Packages.xz
+SHA512:
+ 3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333 1234 main/binary-amd64/Packages
+";
+        let entries: Vec<_> = parse_release_checksums(release).collect();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, "main/binary-amd64/Packages");
+        assert_eq!(entries[0].1, [0x11u8; 32]);
+        assert_eq!(entries[1].0, "main/binary-amd64/Packages.xz");
+        assert_eq!(entries[1].1, [0x22u8; 32]);
+    }
+
+    #[test]
+    fn parse_release_inrelease_clearsigned() {
+        let inrelease = "\
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+Origin: Debian
+SHA256:
+ 1111111111111111111111111111111111111111111111111111111111111111 1234 main/binary-amd64/Packages
+-----BEGIN PGP SIGNATURE-----
+
+iQIzBAEBCgAd...
+-----END PGP SIGNATURE-----
+";
+        let entries: Vec<_> = parse_release_checksums(inrelease).collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "main/binary-amd64/Packages");
+    }
+
+    #[test]
+    fn parse_release_rejects_unsafe_path() {
+        let release = "\
+SHA256:
+ 1111111111111111111111111111111111111111111111111111111111111111 1 ../../etc/passwd
+";
+        assert!(parse_release_checksums(release).next().is_none());
+    }
+
+    #[test]
+    fn hex_decode_exact_rejects_truncated() {
+        assert!(hex_decode_exact::<32>("deadbeef").is_none());
+    }
+
+    #[test]
+    fn hex_decode_exact_rejects_oversize() {
+        let oversize = "a".repeat(128);
+        assert!(hex_decode_exact::<32>(&oversize).is_none());
+    }
+
+    #[test]
+    fn hex_decode_exact_rejects_odd_length() {
+        let odd = "a".repeat(63);
+        assert!(hex_decode_exact::<32>(&odd).is_none());
+    }
+
+    #[test]
+    fn byhash_digest_rejects_non_hex_with_correct_length() {
+        let bad = "g".repeat(64);
+        assert!(byhash_digest_for_algo(HashAlgo::Sha256, &bad).is_none());
     }
 }

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -1,0 +1,1431 @@
+//! Download-commit integrity verification.
+//!
+//! Before a finished download is renamed into the cache, verify its content
+//! against the repository's own metadata: by-hash files self-verify (digest
+//! in the URL); `.deb` (Pool) and `Packages` files are checked against an
+//! in-memory registry populated from streamed `Release` / `Packages` ingest.
+//! Coupled into `guards::RenameBarrier::commit` so no download backend can
+//! skip it.
+//!
+//! Defence in depth only -- APT's client-side GPG check remains the
+//! cryptographic root of trust.
+//!
+//! Scope: verification gates *caching*, not in-flight *delivery*. A client
+//! served concurrently from the same download -- a late joiner streaming the
+//! growing partial file, or one attaching during the post-download `Verifying`
+//! hash window (`ActiveDownloadStatus::Verifying`) -- receives its bytes before
+//! the digest is known. A mismatch then blocks the `rename` (nothing enters the
+//! cache) but cannot unsend what was already streamed; such readers hold an open
+//! FD and finish serving even after the temp file is unlinked. That is
+//! acceptable precisely because this is defence in depth: the concurrent
+//! client's own APT GPG check is the backstop. So a reader path serving an
+//! unverified `Verifying`/`Download` file is by design, not a bug to "fix".
+
+use std::collections::VecDeque;
+use std::num::NonZero;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use hashbrown::{Equivalent, HashMap};
+use log::{debug, error, warn};
+use parking_lot::Mutex;
+use tokio::io::AsyncBufRead;
+
+use crate::error::ErrorReport;
+use crate::limits::LimitedReader;
+use crate::xz_stream::xz_decoder;
+use crate::{
+    cache_layout::ResourceKind,
+    index_parser::{self, HashAlgo, IndexFormat},
+    metrics,
+};
+use crate::{global_checksum_registry, global_config, limits, warn_once_or_info};
+
+/// Why a download could not be committed to the cache. All three variants are
+/// handled by callers exactly as a pre-existing rename failure is handled
+/// today (log, drop the barrier, skip DB records).
+#[derive(Debug)]
+pub(crate) enum CommitError {
+    /// The downloaded content did not match its expected digest.
+    ChecksumMismatch,
+    /// Reading the temp file back for verification failed. Fail-closed: a file
+    /// that cannot be verified does not enter the cache.
+    VerifyIo(std::io::Error),
+    /// `tokio::fs::rename` of the verified temp file failed.
+    Rename(std::io::Error),
+}
+
+impl std::fmt::Display for CommitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ChecksumMismatch => f.write_str("checksum mismatch"),
+            Self::VerifyIo(e) => write!(f, "verification I/O error: {e}"),
+            Self::Rename(e) => write!(f, "rename failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for CommitError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ChecksumMismatch => None,
+            Self::VerifyIo(e) | Self::Rename(e) => Some(e),
+        }
+    }
+}
+
+/// Input for [`verify_temp_file`]. Holds everything the decision needs as plain
+/// borrows so the decision logic is global-free (no `global_config()`, no
+/// process-wide registry) and therefore unit-testable. Note: `verify_temp_file`
+/// performs file I/O (it reads and hashes `temp_path`) - it is not a pure
+/// function, but it is free of process-global state.
+pub(crate) struct VerifyInput<'a> {
+    /// `config.verify_checksums`.
+    pub(crate) verify_enabled: bool,
+    pub(crate) kind: VerifyKind,
+    pub(crate) temp_path: &'a Path,
+}
+
+/// What the downloaded temp file is verified against. Construction (in
+/// `verify_and_rename`) encodes the resource-kind -> expected-digest mapping,
+/// so the pure decision never has to re-derive it - and the old "`ByHash`
+/// always carries a filename" invariant (previously a runtime `.expect()`) is
+/// no longer representable as a mismatched field combination.
+pub(crate) enum VerifyKind {
+    /// By-hash (`ResourceKind::ByHash` / `FlatByHash`): the URL filename is the
+    /// expected hex digest and `algo` is the authoritative algorithm taken from
+    /// the `<algo>` URL path segment (`SHA256`/`SHA512`), NOT inferred from the
+    /// digest length. Self-verifying - the digest is embedded in the request.
+    /// `algo` is `None` when the by-hash URL carried no recognised algorithm
+    /// segment (then treated as unverifiable).
+    ByHash {
+        algo: Option<HashAlgo>,
+        filename: String,
+    },
+    /// Registry-backed (`Pool` .deb / `Packages`): expected SHA256 from the
+    /// in-memory registry, if known. `None` -> cached unverified (best effort).
+    Registry { digest: Option<[u8; 32]> },
+    /// Not verifiable by this module today (other metadata, flat-pool .debs).
+    Unverifiable,
+}
+
+/// Result of the pure verification decision.
+#[derive(Debug)]
+pub(crate) enum VerifyOutcome {
+    /// Verification passed, or was skipped (disabled / non-verifiable / unknown
+    /// digest). The caller proceeds with the `rename`.
+    Proceed,
+    /// Verification failed. The caller must not `rename`.
+    Reject(CommitError),
+}
+
+/// Verification decision. Covers by-hash self-verification plus
+/// registry-backed lookups for `Pool` (.deb) and `Packages` resources.
+///
+/// Global-free (no `global_config()`, no registry): all inputs arrive via
+/// [`VerifyInput`], making this unit-testable. It does perform file I/O
+/// (reads and hashes `temp_path`); callers on an async worker must wrap this
+/// in `spawn_blocking` (see `verify_and_rename`).
+pub(crate) fn verify_temp_file(input: &VerifyInput<'_>) -> VerifyOutcome {
+    if !input.verify_enabled {
+        return VerifyOutcome::Proceed;
+    }
+
+    // Determine the expected (algo, digest), if any.
+    let expected: Option<(HashAlgo, Vec<u8>)> = match &input.kind {
+        VerifyKind::ByHash { algo, filename } => {
+            let decoded = algo
+                .and_then(|a| index_parser::byhash_digest_for_algo(a, filename).map(|d| (a, d)));
+            if decoded.is_none() {
+                // Defence in depth: the URL parser already rejects anything
+                // other than `SHA256/<64-hex>` or `SHA512/<128-hex>` with the
+                // algorithm segment cross-checked against the digest length, so
+                // reaching this branch indicates a future divergence between
+                // the parser and the digest decoder. Keep the warning visible.
+                warn_once_or_info!(
+                    "By-hash digest did not decode for its URL algorithm; caching unverified: `{}`",
+                    filename
+                );
+            }
+            decoded
+        }
+        VerifyKind::Registry { digest } => digest.map(|d| (HashAlgo::Sha256, d.to_vec())),
+        // Flat-pool .debs (Layer-B path-alignment deferred) and other metadata
+        // resources have no registry-backed digest today.
+        VerifyKind::Unverifiable => None,
+    };
+
+    let Some((algo, expected)) = expected else {
+        // Best-effort: no known digest -> cache unverified. Only count it for
+        // kinds that *could* have been verified, so the metric reflects a real
+        // coverage gap rather than every metadata / flat-pool file.
+        if !matches!(input.kind, VerifyKind::Unverifiable) {
+            metrics::CHECKSUM_UNVERIFIED.increment();
+        }
+        return VerifyOutcome::Proceed;
+    };
+
+    let computed = match hash_file(input.temp_path, algo) {
+        Ok(c) => c,
+        Err(err) => {
+            metrics::CACHE_IO_FAILURE.increment();
+            error!(
+                "Failed to read `{}` for {} verification:  {}",
+                input.temp_path.display(),
+                algo.as_str(),
+                ErrorReport(&err),
+            );
+            return VerifyOutcome::Reject(CommitError::VerifyIo(err));
+        }
+    };
+
+    if computed == expected {
+        metrics::CHECKSUM_VERIFIED.increment();
+        VerifyOutcome::Proceed
+    } else {
+        metrics::CHECKSUM_MISMATCH.increment();
+        // WARN (not ERROR): can also be a third-party repo that replaced a
+        // file in place. The async wrapper logs once per mismatch with host
+        // and path in scope; each event is potentially security-relevant so
+        // they are not rate-limited.
+        VerifyOutcome::Reject(CommitError::ChecksumMismatch)
+    }
+}
+
+/// Open `path` with `O_NOFOLLOW`, hint sequential read, and hash it.
+fn hash_file(path: &Path, algo: HashAlgo) -> std::io::Result<Vec<u8>> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let mut file = std::fs::File::options()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(path)?;
+    hint_sequential_read_std(&file, path);
+    match algo {
+        HashAlgo::Sha256 => index_parser::hash_open_file::<sha2::Sha256>(&mut file),
+        HashAlgo::Sha512 => index_parser::hash_open_file::<sha2::Sha512>(&mut file),
+    }
+}
+
+/// Hint sequential read on a `std::fs::File`. Mirrors the logic of
+/// `crate::utils::hint_sequential_read`, which requires `&tokio::fs::File`
+/// and cannot be called from a synchronous context.
+fn hint_sequential_read_std(file: &std::fs::File, path: &Path) {
+    use nix::fcntl::{PosixFadviseAdvice, posix_fadvise};
+
+    if let Err(errno) = posix_fadvise(file, 0, 0, PosixFadviseAdvice::POSIX_FADV_SEQUENTIAL) {
+        // Non-fatal: fall back to the kernel's default readahead policy.
+        debug!(
+            "posix_fadvise(SEQUENTIAL) failed for `{}`:  {errno}",
+            path.display()
+        );
+    }
+}
+
+/// Everything `verify_and_rename` needs, assembled by each download backend at
+/// its rename site and handed to `RenameBarrier::commit`.
+pub(crate) struct RenamePlan {
+    /// The finished `.partial` / temp file to verify and rename.
+    pub(crate) temp_path: PathBuf,
+    /// The final cache path to rename into.
+    pub(crate) dest_path: PathBuf,
+    /// Actual bytes on disk after download (passed through to the barrier's
+    /// `Finished` accounting / quota finalisation). For resumed downloads
+    /// this includes the pre-existing prefix.
+    pub(crate) bytes_received: u64,
+    /// Precise resource kind, from `ConnectionDetails::resource_kind`.
+    pub(crate) resource_kind: ResourceKind,
+    /// On-disk leaf name. For a by-hash resource this is the hex digest, used
+    /// by `verify_temp_file` to decode the expected hash; for `Pool` it is
+    /// the basename used as the registry-lookup key via
+    /// `registry_key_for_download`; for other kinds it is kept only for log
+    /// context.
+    pub(crate) debname: String,
+    /// Upstream host. Part of the registry key, alongside `mirror_path`.
+    pub(crate) host: String,
+    /// Mirror's repo-prefix path (`Mirror::path()`). Part of the registry
+    /// key so two distinct mirrors served from the same host (e.g.
+    /// `host/m1/pool/...` vs `host/m2/pool/...`) cannot poison each other's
+    /// expected digests via same-named packages.
+    pub(crate) mirror_path: String,
+    /// The raw request URI path (pre-normalisation). Used for the by-hash
+    /// ingestion heuristic (segment before `by-hash`), for `Release`
+    /// relative-path resolution, and as the relative-key component of the
+    /// `Packages` registry lookup (see `verify_and_rename`).
+    pub(crate) raw_uri_path: String,
+}
+
+/// Owned `(host, mirror_path, relpath)` registry key. `relpath` is the
+/// resource's agreed lookup key, NOT uniformly "repo-relative": for a pool
+/// `.deb` (layer B) it is the bare basename, for an index file (layer C) it is
+/// the full host-relative URI path (e.g.
+/// `debian/dists/sid/main/binary-amd64/Packages.xz`). `mirror_path`
+/// discriminates same-`relpath` entries that two mirrors on the same host can
+/// otherwise overwrite — see `RenamePlan::mirror_path`. (For layer-C keys
+/// `mirror_path` is a redundant prefix of `relpath`; for layer-B basenames it
+/// is the sole discriminator.)
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct RegistryKey {
+    host: String,
+    mirror_path: String,
+    relpath: String,
+}
+
+/// Borrowed lookup key paired with `RegistryKey` via `hashbrown::Equivalent`,
+/// so `lookup` does not allocate three `String`s per call. Mirrors the
+/// pattern in `active_downloads.rs` (`ActiveDownloadKeyRef`).
+#[derive(Hash)]
+struct RegistryKeyRef<'a> {
+    host: &'a str,
+    mirror_path: &'a str,
+    relpath: &'a str,
+}
+
+impl Equivalent<RegistryKey> for RegistryKeyRef<'_> {
+    fn equivalent(&self, key: &RegistryKey) -> bool {
+        let &Self {
+            host,
+            mirror_path,
+            relpath,
+        } = self;
+        let RegistryKey {
+            host: khost,
+            mirror_path: kmpath,
+            relpath: krelpath,
+        } = key;
+        host == khost && mirror_path == kmpath && relpath == krelpath
+    }
+}
+
+// `RegistryInner.map` keys on `Arc<RegistryKey>` so the eviction-order deque
+// can share the same allocation. Forwarding `Equivalent` here lets `lookup`
+// keep using the borrowed `RegistryKeyRef` (no allocation on the hot path).
+// `Arc<T>: Hash` delegates to `T: Hash` in std, so the hash byte sequence
+// matches `RegistryKey`'s derived hash and `RegistryKeyRef`'s manual impl.
+impl Equivalent<Arc<RegistryKey>> for RegistryKeyRef<'_> {
+    fn equivalent(&self, key: &Arc<RegistryKey>) -> bool {
+        <Self as Equivalent<RegistryKey>>::equivalent(self, key.as_ref())
+    }
+}
+
+/// Bounded in-memory map from a [`RegistryKey`] (`host`, `mirror_path`, resource
+/// lookup key) to an expected SHA256 digest, populated by parsing `Packages` /
+/// `Release` index files as they flow through. In-memory only (lost on restart,
+/// re-populated by the next `apt update`). FIFO bulk eviction at the configured
+/// cap.
+#[derive(Debug)]
+pub(crate) struct ChecksumRegistry {
+    inner: Mutex<RegistryInner>,
+    cap: usize,
+}
+
+#[derive(Debug)]
+struct RegistryInner {
+    /// Maps `Arc<RegistryKey>` to `(digest, generation)`. The generation is
+    /// the value of `next_gen` at the moment of the most recent insert for
+    /// this key. The same `Arc` is also pushed onto `order`, so `insert`
+    /// allocates the three field `String`s once instead of twice.
+    map: HashMap<Arc<RegistryKey>, ([u8; 32], u64)>,
+    /// Insertion-order log for FIFO eviction. Each entry pairs the key with
+    /// the generation it was inserted at. Entries whose generation no longer
+    /// matches `map[key].1` are stale (the key was re-inserted later); the
+    /// eviction loop skips them and `compact_order` periodically removes
+    /// them.
+    order: VecDeque<(Arc<RegistryKey>, u64)>,
+    /// Monotonic counter, incremented on every `insert`. Overflow at 2^64
+    /// is unreachable in practice (millennia at any realistic insert rate).
+    next_gen: u64,
+}
+
+impl ChecksumRegistry {
+    pub(crate) fn new(cap: NonZero<usize>) -> Self {
+        Self {
+            inner: Mutex::new(RegistryInner {
+                map: HashMap::new(),
+                order: VecDeque::new(),
+                next_gen: 0,
+            }),
+            cap: cap.get(),
+        }
+    }
+
+    /// Insert (or refresh) an expected digest. At the cap, evicts the oldest
+    /// ~25% of entries in one pass. Re-inserting an existing key refreshes
+    /// its eviction-order position to most-recent.
+    pub(crate) fn insert(&self, host: &str, mirror_path: &str, relpath: &str, digest: [u8; 32]) {
+        let key = Arc::new(RegistryKey {
+            host: host.to_owned(),
+            mirror_path: mirror_path.to_owned(),
+            relpath: relpath.to_owned(),
+        });
+        let mut inner = self.inner.lock();
+        let generation = inner.next_gen;
+        inner.next_gen += 1;
+        inner.order.push_back((Arc::clone(&key), generation));
+        inner.map.insert(key, (digest, generation));
+        if inner.map.len() > self.cap {
+            evict(&mut inner, self.cap);
+        }
+        if inner.order.len() > 2 * self.cap {
+            compact_order(&mut inner);
+        }
+    }
+
+    /// Look up an expected digest by `(host, mirror_path, relpath)`.
+    /// Allocation-free via `hashbrown::Equivalent`.
+    pub(crate) fn lookup(&self, host: &str, mirror_path: &str, relpath: &str) -> Option<[u8; 32]> {
+        let inner = self.inner.lock();
+        inner
+            .map
+            .get(&RegistryKeyRef {
+                host,
+                mirror_path,
+                relpath,
+            })
+            .map(|&(digest, _)| digest)
+    }
+
+    /// Current entry count (for the web dashboard).
+    pub(crate) fn len(&self) -> usize {
+        self.inner.lock().map.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn order_len(&self) -> usize {
+        self.inner.lock().order.len()
+    }
+}
+
+/// FIFO eviction: pop from the front of `order`, drop live entries whose
+/// generation still matches `map`, skip stale ones (re-inserted keys whose
+/// current generation is newer than the popped one). Stale skips do not
+/// count against `quota`, so each pass frees `min(quota, live remaining)`
+/// map slots.
+fn evict(inner: &mut RegistryInner, cap: usize) {
+    let quota = (cap / 4).max(1);
+    let mut live = 0usize;
+    while live < quota {
+        let Some((key, generation)) = inner.order.pop_front() else {
+            break;
+        };
+        match inner.map.get(&key) {
+            Some(&(_, current_gen)) if current_gen == generation => {
+                inner.map.remove(&key);
+                live += 1;
+            }
+            _ => {
+                // Stale entry: the key was re-inserted later (newer gen) or
+                // already evicted. Drop it; do not consume eviction quota.
+            }
+        }
+    }
+}
+
+/// Rebuild `order` keeping only entries whose generation matches the
+/// current live entry in `map`. Preserves FIFO order of live entries.
+/// Triggered from `insert` when `order.len() > 2 * cap`, so amortized
+/// O(1) per insert. Worst-case pass is O(order.len()).
+fn compact_order(inner: &mut RegistryInner) {
+    let mut compacted = VecDeque::with_capacity(inner.map.len());
+    while let Some(entry) = inner.order.pop_front() {
+        let (ref key, generation) = entry;
+        if inner.map.get(key).map(|&(_, g)| g) == Some(generation) {
+            compacted.push_back(entry);
+        }
+    }
+    inner.order = compacted;
+}
+
+/// Verify the finished temp file and, on success, rename it into place.
+///
+/// Returns `Ok(())` when the file is verified (or verification was
+/// skipped/best-effort) and the rename succeeded. Returns `Err(CommitError)`
+/// on mismatch, verification I/O failure, or rename failure -- in every case
+/// the temp file is left for its `TempPath` drop guard to unlink.
+pub(crate) async fn verify_and_rename(plan: &RenamePlan) -> Result<(), CommitError> {
+    let verify_enabled = global_config().verify_checksums;
+
+    // Build the verification kind. Layer-B/C registry lookups happen here -
+    // synchronously, before spawn_blocking - so the pure decision stays
+    // global-free. Skipped entirely when verification is disabled.
+    let kind = if verify_enabled {
+        match plan.resource_kind {
+            ResourceKind::ByHash | ResourceKind::FlatByHash => VerifyKind::ByHash {
+                algo: byhash_algo_from_uri_path(&plan.raw_uri_path),
+                filename: plan.debname.clone(),
+            },
+            ResourceKind::Pool => VerifyKind::Registry {
+                digest: global_checksum_registry().lookup(
+                    &plan.host,
+                    &plan.mirror_path,
+                    &index_parser::registry_key_for_download(&plan.debname),
+                ),
+            },
+            ResourceKind::Packages => {
+                // Layer C: a Packages file's key is its full host-relative URI
+                // path (what ingest_release_file inserted: "<release_dir>/<rel>").
+                let key = plan.raw_uri_path.trim_start_matches('/');
+                VerifyKind::Registry {
+                    digest: global_checksum_registry().lookup(&plan.host, &plan.mirror_path, key),
+                }
+            }
+            ResourceKind::Release
+            | ResourceKind::ComponentRelease
+            | ResourceKind::Sources
+            | ResourceKind::Translation
+            | ResourceKind::Icon
+            | ResourceKind::FlatMetadata
+            | ResourceKind::FlatPool => VerifyKind::Unverifiable,
+        }
+    } else {
+        VerifyKind::Unverifiable
+    };
+
+    let temp_path = plan.temp_path.clone();
+    let outcome = match tokio::task::spawn_blocking(move || {
+        verify_temp_file(&VerifyInput {
+            verify_enabled,
+            kind,
+            temp_path: &temp_path,
+        })
+    })
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(join_err) => {
+            error!(
+                "Verification task failed for `{}` from host `{}`:  {}",
+                plan.debname,
+                plan.host,
+                ErrorReport(&join_err),
+            );
+            metrics::CACHE_IO_FAILURE.increment();
+            return Err(CommitError::VerifyIo(std::io::Error::other(join_err)));
+        }
+    };
+
+    if let VerifyOutcome::Reject(err) = outcome {
+        if matches!(err, CommitError::ChecksumMismatch) {
+            warn!(
+                "Checksum mismatch for `{}` from host `{}`; not caching",
+                plan.debname, plan.host,
+            );
+        }
+        return Err(err);
+    }
+
+    tokio::fs::rename(&plan.temp_path, &plan.dest_path)
+        .await
+        .map_err(CommitError::Rename)?;
+
+    // Post-commit, best-effort: ingest index files into the registry so future
+    // downloads are verifiable. Detached so the client connection is never
+    // delayed by decompression/parsing. Skipped when verification is disabled:
+    // the registry it populates is read only by `verify_temp_file`, so parsing
+    // (and decompressing) every index file would be pure waste.
+    if verify_enabled {
+        spawn_ingest(plan);
+    }
+
+    Ok(())
+}
+
+/// Spawn a detached best-effort task to parse a just-committed index file into
+/// the registry. No-op for non-index resources.
+fn spawn_ingest(plan: &RenamePlan) {
+    enum IngestKind {
+        Packages {
+            compression: PackagesCompression,
+            format: IndexFormat,
+        },
+        /// Compression unknown (by-hash URL leaf is a hex digest); the
+        /// spawned task sniffs magic bytes before parsing. Required because
+        /// modern APT with `Acquire::By-Hash: yes` fetches `Packages.xz`
+        /// (typically) via `/by-hash/SHA256/<hex>` URLs that carry no
+        /// extension, so the filename-based detection used elsewhere fails.
+        PackagesSniff {
+            format: IndexFormat,
+        },
+        Release {
+            release_dir: String,
+        },
+    }
+
+    // For Packages/FlatMetadata, `plan.debname` is `_`-joined for structured
+    // resources; extract the leaf filename (the part after the last `_`).
+    let leaf = plan
+        .debname
+        .rsplit('_')
+        .next()
+        .expect("rsplit yields at least one element");
+
+    #[expect(clippy::match_same_arms, reason = "prefer clarity")]
+    let kind = match plan.resource_kind {
+        ResourceKind::Packages => {
+            PackagesCompression::from_filename(leaf).map(|c| IngestKind::Packages {
+                compression: c,
+                format: IndexFormat::Structured,
+            })
+        }
+        // Flat Packages files are ingested into the registry (layer-B deb
+        // verification).  Flat-layer-C (verifying a flat Packages file against
+        // a flat Release) is not implemented - consistent with flat-pool layer-B
+        // also being deferred.
+        ResourceKind::FlatMetadata => {
+            PackagesCompression::from_filename(leaf).map(|c| IngestKind::Packages {
+                compression: c,
+                format: IndexFormat::Flat,
+            })
+        }
+        ResourceKind::Release => release_dir_from_uri_path(&plan.raw_uri_path)
+            .map(|d| IngestKind::Release { release_dir: d }),
+        // A per-component Release (`binary-<arch>/Release`) carries no SHA256:
+        // section listing Packages files, so parsing it yields nothing useful.
+        // Route it to the no-op group rather than wasting a file-open + parse.
+        ResourceKind::ComponentRelease => None,
+        // A by-hash file may be a Packages file. The raw URI path's
+        // segment immediately before `by-hash` distinguishes a binary
+        // Packages index from Contents/dep11/i18n by-hash content.
+        ResourceKind::ByHash => {
+            if byhash_path_looks_like_packages(&plan.raw_uri_path) {
+                Some(IngestKind::PackagesSniff {
+                    format: IndexFormat::Structured,
+                })
+            } else {
+                None
+            }
+        }
+        ResourceKind::FlatByHash => {
+            // `byhash_path_looks_like_packages` matches a `binary-*` or
+            // `source` segment before `by-hash`, which is a structured-layout
+            // signature.  Flat by-hash URLs anchor at the flat repo's base
+            // directory and never contain those tokens, so this arm is
+            // effectively dead today.  Flat layer-C ingestion is deferred
+            // (see `verify_and_rename`); leave the call in place to keep
+            // the kind exhaustive.
+            if byhash_path_looks_like_packages(&plan.raw_uri_path) {
+                Some(IngestKind::PackagesSniff {
+                    format: IndexFormat::Flat,
+                })
+            } else {
+                None
+            }
+        }
+        ResourceKind::Pool
+        | ResourceKind::Sources
+        | ResourceKind::Translation
+        | ResourceKind::Icon
+        | ResourceKind::FlatPool => None,
+    };
+    let Some(kind) = kind else { return };
+
+    let host = plan.host.clone();
+    let mirror_path = plan.mirror_path.clone();
+    let dest = plan.dest_path.clone();
+    let buffer_size = global_config().buffer_size;
+    tokio::spawn(async move {
+        let registry = global_checksum_registry();
+        let result = match kind {
+            IngestKind::Packages {
+                compression,
+                format,
+            } => {
+                ingest_packages_file(
+                    registry,
+                    &host,
+                    &mirror_path,
+                    &dest,
+                    compression,
+                    format,
+                    buffer_size,
+                )
+                .await
+            }
+            IngestKind::PackagesSniff { format } => match sniff_packages_compression(&dest).await {
+                Ok(compression) => {
+                    ingest_packages_file(
+                        registry,
+                        &host,
+                        &mirror_path,
+                        &dest,
+                        compression,
+                        format,
+                        buffer_size,
+                    )
+                    .await
+                }
+                Err(err) => Err(err),
+            },
+            IngestKind::Release { release_dir } => {
+                ingest_release_file(registry, &host, &mirror_path, &dest, &release_dir).await
+            }
+        };
+        if let Err(err) = result {
+            debug!(
+                "Index ingestion of `{}` failed:  {}",
+                dest.display(),
+                ErrorReport(&err),
+            );
+        }
+    });
+}
+
+/// The host-relative directory a `dists/.../Release` file lives in, derived
+/// from the raw URI path (the parent directory of the `Release` leaf).
+///
+/// `Release.gpg` is a detached binary PGP signature with no SHA256 section to
+/// ingest, so it's excluded — routing it here would just waste a file open
+/// and a `read_to_string` of opaque bytes.
+fn release_dir_from_uri_path(raw_uri_path: &str) -> Option<String> {
+    let trimmed = raw_uri_path.trim_start_matches('/');
+    let (dir, leaf) = trimmed.rsplit_once('/')?;
+    if !matches!(leaf, "Release" | "InRelease") {
+        return None;
+    }
+    Some(dir.to_owned())
+}
+
+/// `true` iff the raw by-hash URI path's segment immediately before `by-hash`
+/// is a `binary-<arch>` or `source` directory - the only by-hash content that
+/// is a `Packages`/`Sources` index. (`Sources` is parsed identically; its
+/// stanzas carry no `Filename:` line so the parser yields nothing - harmless.)
+fn byhash_path_looks_like_packages(raw_uri_path: &str) -> bool {
+    let mut prev: Option<&str> = None;
+    for seg in raw_uri_path.split('/') {
+        if seg == "by-hash" {
+            return matches!(prev, Some(p) if p.starts_with("binary-") || p == "source");
+        }
+        if !seg.is_empty() {
+            prev = Some(seg);
+        }
+    }
+    false
+}
+
+/// The hash algorithm of a `.../by-hash/<algo>/<hex>` URL, taken from the
+/// segment immediately after `by-hash`. This is the *authoritative* algorithm
+/// for a by-hash resource; the digest length is only cross-checked against it
+/// (in `index_parser::byhash_digest_for_algo`), never used to infer it.
+/// `None` if `by-hash` is absent or the following segment is not a recognised
+/// algorithm - the resource is then cached unverified rather than hashed with a
+/// guessed algorithm.
+fn byhash_algo_from_uri_path(raw_uri_path: &str) -> Option<HashAlgo> {
+    let mut segs = raw_uri_path.split('/').filter(|s| !s.is_empty());
+    while let Some(seg) = segs.next() {
+        if seg == "by-hash" {
+            return match segs.next()? {
+                "SHA256" => Some(HashAlgo::Sha256),
+                "SHA512" => Some(HashAlgo::Sha512),
+                _ => None,
+            };
+        }
+    }
+    None
+}
+
+/// Compression of a `Packages` file, derived from its filename extension.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PackagesCompression {
+    Raw,
+    Gz,
+    Xz,
+}
+
+impl PackagesCompression {
+    /// Derive from a filename leaf. `None` if the leaf does not look like a
+    /// `Packages` file at all.
+    pub(crate) fn from_filename(name: &str) -> Option<Self> {
+        if name == "Packages" {
+            Some(Self::Raw)
+        } else if name == "Packages.gz" {
+            Some(Self::Gz)
+        } else if name == "Packages.xz" {
+            Some(Self::Xz)
+        } else {
+            None
+        }
+    }
+}
+
+/// Detect Packages compression by reading magic bytes from the file. Used for
+/// by-hash content whose URL leaf is a hex digest and so carries no extension.
+/// Falls back to `Raw` if no recognised magic is found (best-effort: a
+/// genuinely raw Packages file with no magic is parsed normally; a corrupt or
+/// unexpected payload yields zero stanzas, which is the same outcome as the
+/// pre-sniff behaviour for any non-`.xz`/non-`.gz` content).
+async fn sniff_packages_compression(path: &Path) -> std::io::Result<PackagesCompression> {
+    use tokio::io::AsyncReadExt as _;
+    let mut file = tokio::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(path)
+        .await?;
+    // Fill up to 6 magic bytes, tolerating short reads (a single `read` may
+    // return fewer bytes than requested) and early EOF (a genuinely tiny raw
+    // `Packages` file is valid and classifies as `Raw`, not an error).
+    let mut buf = [0u8; 6];
+    let mut n = 0;
+    while n < buf.len() {
+        match file.read(&mut buf[n..]).await? {
+            0 => break,
+            read => n += read,
+        }
+    }
+    // gzip: 1F 8B; xz: FD 37 7A 58 5A 00.
+    if n >= 2 && buf[0] == 0x1F && buf[1] == 0x8B {
+        Ok(PackagesCompression::Gz)
+    } else if n >= 6 && &buf[..6] == b"\xfd7zXZ\x00" {
+        Ok(PackagesCompression::Xz)
+    } else {
+        Ok(PackagesCompression::Raw)
+    }
+}
+
+/// Stream a (possibly compressed) `Packages` file and insert every
+/// `(Filename, SHA256)` pair into `registry`. Best-effort: a malformed file
+/// just yields fewer entries; errors are logged and returned.
+///
+/// Guards against decompression bombs: total decompressed output is capped at
+/// the smaller of [`crate::limits::MAX_DECOMPRESSED_PACKAGES_SIZE`] and the
+/// compressed file size multiplied by
+/// [`crate::limits::MAX_DECOMPRESSION_RATIO`] (mirroring `task_cleanup.rs`).
+/// Per-line length is capped at [`crate::limits::MAX_METADATA_LINE_LEN`].
+/// Hitting either cap stops ingestion gracefully (the registry is just
+/// less-populated).
+pub(crate) async fn ingest_packages_file(
+    registry: &ChecksumRegistry,
+    host: &str,
+    mirror_path: &str,
+    path: &std::path::Path,
+    compression: PackagesCompression,
+    format: IndexFormat,
+    buffer_size: usize,
+) -> std::io::Result<()> {
+    let file = tokio::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(nix::libc::O_NOFOLLOW)
+        .open(path)
+        .await?;
+
+    // Compute the decompressed-output ceiling from the compressed file size.
+    // Fall back to the absolute cap if stat fails (non-fatal).
+    let compressed_size = match file.metadata().await {
+        Ok(m) => m.len(),
+        Err(err) => {
+            warn!(
+                "Could not stat `{}` for decompression-ratio guard during Packages ingestion:  {}",
+                path.display(),
+                ErrorReport(&err),
+            );
+            u64::MAX
+        }
+    };
+    let decompressed_limit = match NonZero::new(compressed_size) {
+        Some(cs) => limits::MAX_DECOMPRESSED_PACKAGES_SIZE
+            .min(cs.saturating_mul(limits::MAX_DECOMPRESSION_RATIO)),
+        None => limits::MAX_DECOMPRESSED_PACKAGES_SIZE,
+    };
+
+    let mut raw;
+    let mut gz;
+    let mut xz;
+    let reader: &mut (dyn AsyncBufRead + Unpin + Send) = match compression {
+        PackagesCompression::Raw => {
+            // No inner BufReader here: file -> LimitedReader -> BufReader.
+            // A decompression layer (Gz/Xz) benefits from buffering its
+            // compressed input; raw bytes need no such amortisation.
+            let limited = LimitedReader::new(file, decompressed_limit);
+            raw = tokio::io::BufReader::with_capacity(buffer_size, limited);
+            &mut raw
+        }
+        PackagesCompression::Gz => {
+            let file_reader = tokio::io::BufReader::with_capacity(buffer_size, file);
+            let decoder = async_compression::tokio::bufread::GzipDecoder::new(file_reader);
+            let limited = LimitedReader::new(decoder, decompressed_limit);
+            gz = tokio::io::BufReader::with_capacity(buffer_size, limited);
+            &mut gz
+        }
+        PackagesCompression::Xz => {
+            let file_reader = tokio::io::BufReader::with_capacity(buffer_size, file);
+            let decoder = xz_decoder(file_reader);
+            let limited = LimitedReader::new(decoder, decompressed_limit);
+            xz = tokio::io::BufReader::with_capacity(buffer_size, limited);
+            &mut xz
+        }
+    };
+
+    let mut line = String::with_capacity(128);
+    let mut line_buf: Vec<u8> = Vec::with_capacity(128);
+    let mut stanza = index_parser::Stanza::new();
+    loop {
+        line.clear();
+        match limits::read_line_capped(
+            &mut *reader,
+            &mut line,
+            &mut line_buf,
+            limits::MAX_METADATA_LINE_LEN,
+        )
+        .await
+        {
+            Ok(limits::CappedLine::Eof) => {
+                flush_stanza_into_registry(&mut stanza, registry, host, mirror_path, format);
+                return Ok(());
+            }
+            Ok(limits::CappedLine::Skipped) => {
+                // A line longer than MAX_METADATA_LINE_LEN can't be one of
+                // the fields the stanza parser cares about (Filename,
+                // SHA256, SHA512 are all well under the cap). Treat it as a
+                // non-blank line so the stanza isn't flushed prematurely.
+            }
+            Ok(limits::CappedLine::Line { bytes: _ }) => {
+                if line.trim().is_empty() {
+                    flush_stanza_into_registry(&mut stanza, registry, host, mirror_path, format);
+                } else {
+                    stanza.ingest(&line);
+                }
+            }
+            Err(err) => {
+                warn!(
+                    "Failed to read `{}` during Packages ingestion (may exceed size/line limits):  {}",
+                    path.display(),
+                    ErrorReport(&err),
+                );
+                return Err(err);
+            }
+        }
+    }
+}
+
+/// Parse a `Release` / `InRelease` file and insert its `Packages*` entries
+/// into the registry. `release_dir` is the host-relative directory the
+/// `Release` file lives in (`Release`'s entry paths are relative to it).
+///
+/// Only entries whose leaf matches a `Packages` file are inserted - those are
+/// the only `Release`-listed resources the proxy verifies (layer C). Other
+/// entries (`Contents-*`, `Translation-*`, ...) are skipped.
+pub(crate) async fn ingest_release_file(
+    registry: &ChecksumRegistry,
+    host: &str,
+    mirror_path: &str,
+    path: &std::path::Path,
+    release_dir: &str,
+) -> std::io::Result<()> {
+    let content = {
+        let file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(nix::libc::O_NOFOLLOW)
+            .open(path)
+            .await?;
+        // Cap the in-memory read so a hostile or buggy mirror serving a
+        // multi-GB `Release` (which passes the `max_object_size` admission
+        // check) cannot balloon ingest memory unbounded.
+        let mut limited = LimitedReader::new(file, limits::MAX_RELEASE_SIZE);
+        let mut buf = String::new();
+        tokio::io::AsyncReadExt::read_to_string(&mut limited, &mut buf).await?;
+        buf
+    };
+
+    for (rel, digest) in index_parser::parse_release_checksums(&content) {
+        // Only Packages files are verified at layer C.
+        let leaf = rel
+            .rsplit('/')
+            .next()
+            .expect("rsplit yields at least one element");
+        if PackagesCompression::from_filename(leaf).is_none() {
+            continue;
+        }
+        // Resolve to the host-relative key (matches the Packages lookup key):
+        // <release_dir>/<rel>.
+        let key = format!("{}/{}", release_dir.trim_end_matches('/'), rel);
+        registry.insert(host, mirror_path, &key, digest);
+    }
+    Ok(())
+}
+
+fn flush_stanza_into_registry(
+    stanza: &mut index_parser::Stanza,
+    registry: &ChecksumRegistry,
+    host: &str,
+    mirror_path: &str,
+    format: IndexFormat,
+) {
+    if let Some(filename) = stanza.filename.as_deref()
+        && let Some(sha256) = stanza.sha256
+        && let Some(key) = index_parser::registry_key_from_filename_field(filename, format)
+    {
+        registry.insert(host, mirror_path, &key, sha256);
+    }
+    stanza.reset();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn temp_file_with(content: &[u8]) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("create temp file");
+        f.write_all(content).expect("write temp file");
+        f.flush().expect("flush");
+        f
+    }
+
+    // sha256("hello world") =
+    // b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+    const HELLO_SHA256: &str = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+
+    #[test]
+    fn byhash_match_returns_proceed() {
+        let f = temp_file_with(b"hello world");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::ByHash {
+                algo: Some(HashAlgo::Sha256),
+                filename: HELLO_SHA256.to_string(),
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(verify_temp_file(&plan), VerifyOutcome::Proceed));
+    }
+
+    #[test]
+    fn byhash_mismatch_returns_reject() {
+        let f = temp_file_with(b"tampered");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::ByHash {
+                algo: Some(HashAlgo::Sha256),
+                filename: HELLO_SHA256.to_string(),
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(
+            verify_temp_file(&plan),
+            VerifyOutcome::Reject(CommitError::ChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn disabled_returns_proceed_without_hashing() {
+        let f = temp_file_with(b"tampered");
+        let plan = VerifyInput {
+            verify_enabled: false,
+            kind: VerifyKind::ByHash {
+                algo: Some(HashAlgo::Sha256),
+                filename: HELLO_SHA256.to_string(),
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(verify_temp_file(&plan), VerifyOutcome::Proceed));
+    }
+
+    #[test]
+    fn non_verifiable_kind_returns_proceed() {
+        let f = temp_file_with(b"anything");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::Unverifiable,
+            temp_path: f.path(),
+        };
+        assert!(matches!(verify_temp_file(&plan), VerifyOutcome::Proceed));
+    }
+
+    #[test]
+    fn unreadable_temp_file_returns_reject_verifyio() {
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::ByHash {
+                algo: Some(HashAlgo::Sha256),
+                filename: HELLO_SHA256.to_string(),
+            },
+            temp_path: std::path::Path::new("/nonexistent/apt-cacher-rs/x"),
+        };
+        assert!(matches!(
+            verify_temp_file(&plan),
+            VerifyOutcome::Reject(CommitError::VerifyIo(_))
+        ));
+    }
+
+    #[test]
+    fn pool_with_known_matching_digest_proceeds() {
+        let f = temp_file_with(b"hello world");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::Registry {
+                digest: Some(index_parser::hex_decode_exact::<32>(HELLO_SHA256).unwrap()),
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(verify_temp_file(&plan), VerifyOutcome::Proceed));
+    }
+
+    #[test]
+    fn pool_with_known_mismatching_digest_rejects() {
+        let f = temp_file_with(b"tampered deb");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::Registry {
+                digest: Some([0u8; 32]),
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(
+            verify_temp_file(&plan),
+            VerifyOutcome::Reject(CommitError::ChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn packages_with_known_matching_digest_proceeds() {
+        let f = temp_file_with(b"hello world");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::Registry {
+                digest: Some(index_parser::hex_decode_exact::<32>(HELLO_SHA256).unwrap()),
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(verify_temp_file(&plan), VerifyOutcome::Proceed));
+    }
+
+    #[test]
+    fn packages_with_mismatching_digest_rejects() {
+        let f = temp_file_with(b"tampered packages");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::Registry {
+                digest: Some([0u8; 32]),
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(
+            verify_temp_file(&plan),
+            VerifyOutcome::Reject(CommitError::ChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn pool_with_unknown_digest_proceeds_best_effort() {
+        let f = temp_file_with(b"some deb");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::Registry { digest: None },
+            temp_path: f.path(),
+        };
+        assert!(matches!(verify_temp_file(&plan), VerifyOutcome::Proceed));
+    }
+
+    #[test]
+    fn registry_insert_and_lookup() {
+        use std::num::NonZero;
+        let reg = ChecksumRegistry::new(NonZero::new(100).unwrap());
+        reg.insert(
+            "deb.debian.org",
+            "debian",
+            "pool/main/f/foo/foo_1_amd64.deb",
+            [1u8; 32],
+        );
+        assert_eq!(
+            reg.lookup(
+                "deb.debian.org",
+                "debian",
+                "pool/main/f/foo/foo_1_amd64.deb"
+            ),
+            Some([1u8; 32])
+        );
+        assert_eq!(
+            reg.lookup("deb.debian.org", "debian", "pool/main/f/foo/other.deb"),
+            None
+        );
+        assert_eq!(
+            reg.lookup("other.host", "debian", "pool/main/f/foo/foo_1_amd64.deb"),
+            None
+        );
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn registry_discriminates_mirrors_on_same_host() {
+        use std::num::NonZero;
+        let reg = ChecksumRegistry::new(NonZero::new(100).unwrap());
+        // Same host, same basename, different mirror_path -> distinct entries.
+        reg.insert("host", "m1", "foo_1_amd64.deb", [1u8; 32]);
+        reg.insert("host", "m2", "foo_1_amd64.deb", [2u8; 32]);
+        assert_eq!(reg.lookup("host", "m1", "foo_1_amd64.deb"), Some([1u8; 32]));
+        assert_eq!(reg.lookup("host", "m2", "foo_1_amd64.deb"), Some([2u8; 32]));
+        assert_eq!(reg.len(), 2);
+    }
+
+    #[test]
+    fn registry_evicts_oldest_at_cap() {
+        use std::num::NonZero;
+        let reg = ChecksumRegistry::new(NonZero::new(4).unwrap());
+        for i in 0..4u8 {
+            reg.insert("h", "m", &format!("p{i}"), [i; 32]);
+        }
+        assert_eq!(reg.len(), 4);
+        // Inserting past the cap evicts the oldest batch.
+        reg.insert("h", "m", "p4", [4u8; 32]);
+        assert!(reg.len() <= 4, "registry stayed within cap");
+        assert_eq!(
+            reg.lookup("h", "m", "p4"),
+            Some([4u8; 32]),
+            "newest entry present"
+        );
+        assert_eq!(reg.lookup("h", "m", "p0"), None, "oldest entry evicted");
+    }
+
+    #[test]
+    fn registry_reinsert_refreshes_value() {
+        use std::num::NonZero;
+        let reg = ChecksumRegistry::new(NonZero::new(100).unwrap());
+        reg.insert("h", "m", "p", [1u8; 32]);
+        reg.insert("h", "m", "p", [2u8; 32]);
+        assert_eq!(reg.lookup("h", "m", "p"), Some([2u8; 32]));
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn registry_reinsert_refreshes_eviction_position() {
+        use std::num::NonZero;
+        let reg = ChecksumRegistry::new(NonZero::new(4).unwrap());
+        let d = [0u8; 32];
+        reg.insert("h", "m", "a", d);
+        reg.insert("h", "m", "b", d);
+        reg.insert("h", "m", "c", d);
+        reg.insert("h", "m", "d", d);
+        // Refresh A -- order should now logically be B, C, D, A.
+        reg.insert("h", "m", "a", d);
+        // E pushes over cap (4) -> eviction drops oldest live entry, which is B.
+        reg.insert("h", "m", "e", d);
+        assert!(
+            reg.lookup("h", "m", "a").is_some(),
+            "A should survive re-insert refresh"
+        );
+        assert!(
+            reg.lookup("h", "m", "b").is_none(),
+            "B should be evicted first"
+        );
+        assert!(reg.lookup("h", "m", "c").is_some());
+        assert!(reg.lookup("h", "m", "d").is_some());
+        assert!(reg.lookup("h", "m", "e").is_some());
+    }
+
+    #[test]
+    fn byhash_packages_heuristic() {
+        assert!(byhash_path_looks_like_packages(
+            "/debian/dists/sid/main/binary-amd64/by-hash/SHA256/abcd"
+        ));
+        assert!(byhash_path_looks_like_packages(
+            "/debian/dists/sid/main/source/by-hash/SHA256/abcd"
+        ));
+        assert!(!byhash_path_looks_like_packages(
+            "/debian/dists/sid/main/dep11/by-hash/SHA256/abcd"
+        ));
+        assert!(!byhash_path_looks_like_packages(
+            "/debian/dists/sid/by-hash/SHA256/abcd"
+        ));
+    }
+
+    #[test]
+    fn byhash_algo_extraction() {
+        assert_eq!(
+            byhash_algo_from_uri_path("/debian/dists/sid/main/binary-amd64/by-hash/SHA256/abcd"),
+            Some(HashAlgo::Sha256)
+        );
+        assert_eq!(
+            byhash_algo_from_uri_path("/debian/dists/sid/main/binary-amd64/by-hash/SHA512/abcd"),
+            Some(HashAlgo::Sha512)
+        );
+        // Unrecognised algorithm segment, or no by-hash marker at all.
+        assert_eq!(
+            byhash_algo_from_uri_path("/debian/dists/sid/main/binary-amd64/by-hash/MD5Sum/abcd"),
+            None
+        );
+        assert_eq!(byhash_algo_from_uri_path("/debian/pool/x/foo.deb"), None);
+    }
+
+    #[test]
+    fn byhash_length_algo_mismatch_caches_unverified() {
+        // A SHA512 URL segment carrying a 64-hex (SHA256-length) digest is a
+        // length/algo mismatch: it must NOT be hashed as SHA256. It decodes to
+        // None -> Proceed (cached unverified), never a spurious mismatch.
+        let f = temp_file_with(b"hello world");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::ByHash {
+                algo: Some(HashAlgo::Sha512),
+                filename: HELLO_SHA256.to_string(), // 64 hex chars
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(verify_temp_file(&plan), VerifyOutcome::Proceed));
+    }
+
+    #[test]
+    fn byhash_missing_algo_caches_unverified() {
+        // No algorithm from the URL -> unverifiable, even if the filename would
+        // decode as some digest.
+        let f = temp_file_with(b"hello world");
+        let plan = VerifyInput {
+            verify_enabled: true,
+            kind: VerifyKind::ByHash {
+                algo: None,
+                filename: HELLO_SHA256.to_string(),
+            },
+            temp_path: f.path(),
+        };
+        assert!(matches!(verify_temp_file(&plan), VerifyOutcome::Proceed));
+    }
+
+    #[test]
+    fn release_dir_extraction() {
+        assert_eq!(
+            release_dir_from_uri_path("/debian/dists/sid/Release"),
+            Some("debian/dists/sid".to_string())
+        );
+        assert_eq!(
+            release_dir_from_uri_path("/debian/dists/sid/InRelease"),
+            Some("debian/dists/sid".to_string())
+        );
+        assert_eq!(release_dir_from_uri_path("/debian/pool/x/foo.deb"), None);
+        // Release.gpg is a detached binary PGP signature with no SHA256
+        // section, so the ingest dispatcher must not route it here.
+        assert_eq!(
+            release_dir_from_uri_path("/debian/dists/sid/Release.gpg"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn ingest_release_populates_packages_digests() {
+        use std::io::Write as _;
+        use std::num::NonZero;
+
+        let reg = ChecksumRegistry::new(NonZero::new(100).unwrap());
+        let pkg_sha = [0x77u8; 32];
+        let release = format!(
+            "Origin: Test\nSHA256:\n 0000000000000000000000000000000000000000000000000000000000000000 1 main/binary-amd64/Release\n {} 4242 main/binary-amd64/Packages.xz\n",
+            index_parser::hex_encode(&pkg_sha),
+        );
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        f.write_all(release.as_bytes()).expect("write");
+        f.flush().expect("flush");
+
+        // The Release file lives at dists/sid/Release; its entries are relative
+        // to dists/sid/.
+        ingest_release_file(
+            &reg,
+            "deb.debian.org",
+            "debian",
+            f.path(),
+            "debian/dists/sid",
+        )
+        .await
+        .expect("ingest ok");
+
+        assert_eq!(
+            reg.lookup(
+                "deb.debian.org",
+                "debian",
+                "debian/dists/sid/main/binary-amd64/Packages.xz"
+            ),
+            Some(pkg_sha),
+        );
+    }
+
+    #[tokio::test]
+    async fn ingest_packages_populates_registry() {
+        use std::io::Write as _;
+        use std::num::NonZero;
+
+        let reg = ChecksumRegistry::new(NonZero::new(100).unwrap());
+        // Two minimal Packages stanzas (raw, uncompressed).
+        let sha_a = [0xaau8; 32];
+        let sha_b = [0xbbu8; 32];
+        let packages = format!(
+            "Package: a\nFilename: pool/main/a/a/a_1_amd64.deb\nSHA256: {}\n\n\
+             Package: b\nFilename: pool/main/b/b/b_2_amd64.deb\nSHA256: {}\n",
+            index_parser::hex_encode(&sha_a),
+            index_parser::hex_encode(&sha_b),
+        );
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        f.write_all(packages.as_bytes()).expect("write");
+        f.flush().expect("flush");
+
+        ingest_packages_file(
+            &reg,
+            "deb.debian.org",
+            "debian",
+            f.path(),
+            PackagesCompression::Raw,
+            IndexFormat::Structured,
+            64 * 1024,
+        )
+        .await
+        .expect("ingest ok");
+
+        assert_eq!(
+            reg.lookup("deb.debian.org", "debian", "a_1_amd64.deb"),
+            Some(sha_a)
+        );
+        assert_eq!(
+            reg.lookup("deb.debian.org", "debian", "b_2_amd64.deb"),
+            Some(sha_b)
+        );
+    }
+
+    #[test]
+    fn registry_reinsert_does_not_evict_live_under_stale_pressure() {
+        use std::num::NonZero;
+        let reg = ChecksumRegistry::new(NonZero::new(4).unwrap());
+        let d = [0u8; 32];
+        reg.insert("h", "m", "a", d);
+        reg.insert("h", "m", "b", d);
+        reg.insert("h", "m", "c", d);
+        reg.insert("h", "m", "d", d);
+        // Refresh A 100 times. Each re-insert leaves a stale order entry
+        // (until compaction fires at order.len() > 2*cap=8) but moves A to
+        // the logical back of FIFO.
+        for _ in 0..100 {
+            reg.insert("h", "m", "a", d);
+        }
+        // After all refreshes, A is the most-recently-inserted live entry.
+        // B is the FIFO oldest.
+        reg.insert("h", "m", "e", d);
+        assert!(
+            reg.lookup("h", "m", "a").is_some(),
+            "A: most-recently refreshed must survive"
+        );
+        assert!(
+            reg.lookup("h", "m", "b").is_none(),
+            "B: true FIFO oldest at eviction time"
+        );
+        assert!(reg.lookup("h", "m", "c").is_some());
+        assert!(reg.lookup("h", "m", "d").is_some());
+        assert!(reg.lookup("h", "m", "e").is_some());
+    }
+
+    #[test]
+    fn registry_order_compaction_bounds_memory() {
+        use std::num::NonZero;
+        let reg = ChecksumRegistry::new(NonZero::new(4).unwrap());
+        let d = [0u8; 32];
+        reg.insert("h", "m", "a", d);
+        // 20 re-inserts of the same key (well past the 2*cap=8 trigger).
+        // Compaction must fire at least twice during this loop.
+        for _ in 0..20 {
+            reg.insert("h", "m", "a", d);
+        }
+        // After every insert, the compaction trigger (order.len() > 8) is
+        // either inert (<=8) or fires and drops order back to map.len()=1.
+        // So order_len observed from outside is always <= 8.
+        assert!(
+            reg.order_len() <= 2 * 4,
+            "order_len={} should be bounded by 2*cap=8 after compaction",
+            reg.order_len()
+        );
+        assert_eq!(reg.len(), 1, "map still holds exactly one live entry");
+        assert!(reg.lookup("h", "m", "a").is_some());
+    }
+}

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -36,6 +36,14 @@ pub(crate) const MAX_UPSTREAM_HEADERS: usize = 32;
 /// Absolute ceiling (bytes) on the decompressed output of a `Packages` file.
 pub(crate) const MAX_DECOMPRESSED_PACKAGES_SIZE: NonZero<u64> = nonzero!(1024 * 1024 * 1024);
 
+/// Maximum size (bytes) of a `Release` / `InRelease` file ingested into the
+/// checksum registry. Real Release files for Debian-scale archives are tens
+/// of KB; an 8 MiB cap leaves several orders of magnitude of headroom while
+/// bounding the memory ballooning surface from a hostile or buggy mirror
+/// (which could otherwise serve a multi-GB `Release` under `max_object_size`
+/// and force `read_to_string` to grow without bound).
+pub(crate) const MAX_RELEASE_SIZE: NonZero<u64> = nonzero!(8 * 1024 * 1024);
+
 /// Maximum decompressed-to-compressed ratio tolerated for a `Packages` file.
 pub(crate) const MAX_DECOMPRESSION_RATIO: NonZero<u64> = nonzero!(100);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod http_range;
 mod humanfmt;
 mod hyper_conn;
 mod index_parser;
+mod integrity;
 #[cfg(feature = "ktls")]
 mod ktls;
 #[cfg(feature = "ktls")]
@@ -590,6 +591,7 @@ struct RuntimeDetails {
     start_time: time::OffsetDateTime,
     config: config::Config,
     cache_quota: cache_quota::CacheQuota,
+    checksum_registry: integrity::ChecksumRegistry,
 }
 
 #[derive(Clone, Debug)]
@@ -654,6 +656,15 @@ pub(crate) fn global_cache_quota() -> &'static cache_quota::CacheQuota {
         .get()
         .expect("Global was initialized in main()")
         .cache_quota
+}
+
+#[must_use]
+#[inline]
+pub(crate) fn global_checksum_registry() -> &'static integrity::ChecksumRegistry {
+    &RUNTIMEDETAILS
+        .get()
+        .expect("Global was initialized in main()")
+        .checksum_registry
 }
 
 #[cfg(feature = "tls_rustls")]
@@ -817,11 +828,14 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let config_http_timeout = config.http_timeout;
 
+    let checksum_registry = integrity::ChecksumRegistry::new(config.verify_checksums_max_entries);
+
     RUNTIMEDETAILS
         .set(RuntimeDetails {
             start_time: time::OffsetDateTime::now_utc(),
             cache_quota: cache_quota::CacheQuota::new(0, config.disk_quota),
             config,
+            checksum_registry,
         })
         .expect("Initial set in main() should succeed");
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -146,6 +146,15 @@ pub(crate) static VOLATILE_REFETCHED_UPTODATE: Counter = Counter::new();
 /// Subset of `VOLATILE_REFETCHED`: stale-but-present, upstream returned a fresh body.
 pub(crate) static VOLATILE_REFETCHED_OUTOFDATE: Counter = Counter::new();
 
+/// Downloads whose content matched its expected digest before being committed
+/// to the cache.
+pub(crate) static CHECKSUM_VERIFIED: Counter = Counter::new();
+/// Downloads rejected because their content did not match the expected digest.
+pub(crate) static CHECKSUM_MISMATCH: Counter = Counter::new();
+/// Verifiable-kind downloads committed to the cache without a known expected
+/// digest (best-effort coverage gap).
+pub(crate) static CHECKSUM_UNVERIFIED: Counter = Counter::new();
+
 /// Body-write failures attributed to the client (`BrokenPipe` /
 /// `ConnectionReset` / `ConnectionAborted`).
 ///

--- a/src/request_dispatch.rs
+++ b/src/request_dispatch.rs
@@ -34,7 +34,7 @@ use log::{info, trace};
 
 use crate::{
     ClientInfo,
-    cache_layout::{self, CacheLayout, CachedFlavor, ClassifyError},
+    cache_layout::{self, CacheLayout, CachedFlavor, ClassifyError, ResourceKind},
     config::{Alias, CacheHost, ClientHost, resolve_alias},
     database_task::{DatabaseCommand, DbCmdOrigin, send_db_command},
     deb_mirror::{
@@ -58,6 +58,7 @@ pub(crate) struct CachePlan {
     pub(crate) cached_flavor: CachedFlavor,
     pub(crate) layout: CacheLayout,
     pub(crate) request_received_at: PreciseInstant,
+    pub(crate) resource_kind: ResourceKind,
     _private: (),
 }
 
@@ -311,6 +312,7 @@ fn decide_request(
                             cached_flavor: class.cached_flavor,
                             layout: class.layout,
                             request_received_at,
+                            resource_kind: class.resource_kind,
                             _private: (),
                         },
                         pending_origin,

--- a/src/sendfile_conn.rs
+++ b/src/sendfile_conn.rs
@@ -735,6 +735,7 @@ async fn try_sendfile_request(
         debname: plan.debname,
         cached_flavor: plan.cached_flavor,
         layout: plan.layout,
+        resource_kind: plan.resource_kind,
     };
 
     // Check if the file is currently being downloaded — if so, serve it via
@@ -1828,10 +1829,15 @@ pub(crate) async fn async_sendfile_unfinished(
             let _: Never = match receiver.changed().await {
                 Ok(()) => continue,
                 Err(_err @ tokio::sync::watch::error::RecvError { .. }) => {
-                    // Sender dropped — download finished or aborted.
+                    // Sender dropped — download finished, verifying, or
+                    // aborted. Verifying means all bytes are on disk and the
+                    // writer is hashing on a blocking thread; the open file
+                    // handle stays valid across the upcoming rename, so drain
+                    // like Finished.
                     let st = status.read().await;
                     match *st {
-                        ActiveDownloadStatus::Finished { .. } => {
+                        ActiveDownloadStatus::Finished { .. }
+                        | ActiveDownloadStatus::Verifying { .. } => {
                             drop(st);
                             finished = true;
                             continue;
@@ -1881,7 +1887,8 @@ pub(crate) async fn async_sendfile_unfinished(
                 let (is_finished, is_aborted) = {
                     let st = status.read().await;
                     match *st {
-                        ActiveDownloadStatus::Finished { .. } => (true, false),
+                        ActiveDownloadStatus::Finished { .. }
+                        | ActiveDownloadStatus::Verifying { .. } => (true, false),
                         ActiveDownloadStatus::Aborted(_) => (false, true),
                         ActiveDownloadStatus::Init(_) | ActiveDownloadStatus::Download { .. } => {
                             (false, false)
@@ -2025,6 +2032,55 @@ async fn serve_unfinished_sendfile(
                         (conn_version, conn_action),
                         headers,
                         prefetched.as_deref(),
+                    )
+                    .await
+                    .into();
+                }
+                ActiveDownloadStatus::Verifying {
+                    path,
+                    content_length: _,
+                    meta,
+                } => {
+                    // All bytes are on disk; the writer is hashing and about
+                    // to rename. Open the partial path now — the inode stays
+                    // valid across the upcoming rename. On the rare ENOENT
+                    // race (open after the rename completes but before the
+                    // status flip lands), re-loop and pick up Finished.
+                    let verifying_path = path.clone();
+                    let prefetched = Arc::clone(meta);
+                    drop(st);
+
+                    let file = match tokio::fs::File::options()
+                        .read(true)
+                        .custom_flags(nix::libc::O_NOFOLLOW)
+                        .open(&verifying_path)
+                        .await
+                    {
+                        Ok(f) => f,
+                        Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                        Err(err) => {
+                            metrics::CACHE_IO_FAILURE.increment();
+                            error!(
+                                "Failed to open verifying file `{}` for joining client {}:  {}",
+                                verifying_path.display(),
+                                conn_details.client,
+                                ErrorReport(&err)
+                            );
+                            return ZeroCopyResult::Invalid {
+                                status: StatusCode::INTERNAL_SERVER_ERROR,
+                                msg: "Cache Access Failure",
+                            };
+                        }
+                    };
+
+                    return serve_file_via_sendfile(
+                        stream,
+                        conn_details,
+                        aliased,
+                        (file, &verifying_path),
+                        (conn_version, conn_action),
+                        headers,
+                        Some(&prefetched),
                     )
                     .await
                     .into();

--- a/src/splice_conn.rs
+++ b/src/splice_conn.rs
@@ -28,7 +28,6 @@ use tokio::{
     net::{TcpStream, unix::pipe},
 };
 
-use crate::cache_layout;
 use crate::cache_layout::{CachedFlavor, ConnectionDetails, SUBDIR_TMP};
 use crate::cache_quota::QuotaExceeded;
 use crate::config::{ClientHost, HttpsUpgradeMode};
@@ -52,7 +51,7 @@ use crate::humanfmt::HumanFmt;
 use crate::ktls;
 #[cfg(feature = "ktls")]
 use crate::ktls_handshake::{discard_incoming, encode_tls_data, grow_incoming};
-use crate::limits::{MAX_UPSTREAM_HEADER_SIZE, MAX_UPSTREAM_HEADERS};
+use crate::limits::{self, MAX_UPSTREAM_HEADER_SIZE, MAX_UPSTREAM_HEADERS};
 use crate::precise_instant::PreciseInstant;
 use crate::rate_checker::{InsufficientRate, RateCheckDirection, RateChecker};
 use crate::rate_log;
@@ -79,6 +78,7 @@ use crate::{
 };
 #[cfg(feature = "ktls")]
 use crate::{KTLS_BLOCKED, warn_once};
+use crate::{cache_layout, integrity};
 
 // On Linux, EAGAIN and EWOULDBLOCK share the same numeric value, so matching
 // one variant is equivalent to matching both. The nix crate models EWOULDBLOCK
@@ -4853,7 +4853,7 @@ async fn splice_proxy_drive(
         .map_err(|err| SpliceProxyError::Client(err, "zero total-size 502"))?;
         return Ok(());
     };
-    if !crate::limits::content_length_within_cap(
+    if !limits::content_length_within_cap(
         total_content_length.get(),
         global_config().max_object_size,
     ) {
@@ -5533,27 +5533,54 @@ async fn splice_proxy_drive(
     // path of the downloading state is going to be moved.
     let rbarrier = dbarrier.begin_rename().await;
 
-    match tokio::fs::rename(&temppath, &dest_file_path).await {
+    // Use the actual on-disk size rather than the declared Content-Length.
+    // Earlier validation (Content-Range agreement + EOF check) ensures these
+    // match today, but the defensive stat keeps the quota-finalisation input
+    // honest if a future change weakens an upstream invariant.
+    let actual_bytes = match tokio::fs::metadata(temppath.as_ref()).await {
+        Ok(m) => m.len(),
+        Err(err) => {
+            warn!(
+                "splice proxy: failed to stat temp file `{}` post-sync; using declared Content-Length:  {}",
+                temppath.display(),
+                ErrorReport(&err)
+            );
+            total_content_length.get()
+        }
+    };
+    let plan = integrity::RenamePlan {
+        temp_path: temppath.to_path_buf(),
+        dest_path: dest_file_path.clone(),
+        bytes_received: actual_bytes,
+        resource_kind: conn_details.resource_kind,
+        debname: conn_details.debname.clone(),
+        host: conn_details.mirror.host().to_string(),
+        mirror_path: conn_details.mirror.path().to_owned(),
+        // Use the original (pre-redirect) client request path so registry
+        // keys are consistent with the hyper backend (main.rs), which always
+        // uses `req.uri().path()` captured before any redirect.
+        raw_uri_path: original_uri_path.to_owned(),
+    };
+    match rbarrier.commit(plan).await {
         Ok(()) => {
             TempPath::defuse(temppath);
-
-            rbarrier.release(dest_file_path, total_content_length.get());
         }
         Err(err) => {
-            drop(rbarrier);
-            metrics::CACHE_IO_FAILURE.increment();
-            error!(
-                "splice proxy: failed to rename temp file `{}` to `{}`:  {err}",
-                temppath.display(),
-                dest_file_path.display()
-            );
-            // The body was already fully delivered to the client; this
-            // failure only leaves the cache in an inconsistent state
-            // (the temp file will be cleaned up by its Drop guard, and
-            // future requests will re-download).  Report success to the
-            // caller so the connection stays alive and skip the DB
-            // Download/Delivery/Origin records that would otherwise
-            // claim the file is cached.
+            // commit() dropped the barrier and logged mismatch / verify-IO;
+            // log rename failures here. The body was already fully delivered
+            // to the client; this only leaves the cache without the file
+            // (the TempPath guard removes the temp file, future requests
+            // re-download). Report success so the connection stays alive and
+            // skip the DB Download/Delivery/Origin records.
+            if let integrity::CommitError::Rename(io_err) = &err {
+                metrics::CACHE_IO_FAILURE.increment();
+                error!(
+                    "splice proxy: failed to rename temp file `{}` to `{}`:  {}",
+                    temppath.display(),
+                    dest_file_path.display(),
+                    ErrorReport(io_err)
+                );
+            }
             return Ok(());
         }
     }
@@ -6356,21 +6383,53 @@ async fn handle_volatile_buffered_download(
     let dest_file_path = dest_dir.join(filename);
     let rbarrier = dbarrier.begin_rename().await;
 
-    match tokio::fs::rename(&temppath, &dest_file_path).await {
+    // Use the actual on-disk size rather than the declared Content-Length.
+    // The buffered path writes the entire `body` Vec so these match today,
+    // but the defensive stat keeps the quota-finalisation input honest.
+    let actual_bytes = match tokio::fs::metadata(temppath.as_ref()).await {
+        Ok(m) => m.len(),
+        Err(err) => {
+            warn!(
+                "splice proxy: failed to stat temp file `{}` post-sync; using buffered body length:  {}",
+                temppath.display(),
+                ErrorReport(&err)
+            );
+            total_content_length.get()
+        }
+    };
+    let plan = integrity::RenamePlan {
+        temp_path: temppath.to_path_buf(),
+        dest_path: dest_file_path.clone(),
+        bytes_received: actual_bytes,
+        resource_kind: conn_details.resource_kind,
+        debname: conn_details.debname.clone(),
+        host: conn_details.mirror.host().to_string(),
+        mirror_path: conn_details.mirror.path().to_owned(),
+        // Use the original (pre-redirect) client request path so registry
+        // keys are consistent with the hyper backend (main.rs), which always
+        // uses `req.uri().path()` captured before any redirect.
+        raw_uri_path: original_uri_path.to_owned(),
+    };
+    match rbarrier.commit(plan).await {
         Ok(()) => {
             TempPath::defuse(temppath);
-            rbarrier.release(dest_file_path, total_content_length.get());
         }
         Err(err) => {
-            drop(rbarrier);
-            metrics::CACHE_IO_FAILURE.increment();
-            error!(
-                "splice proxy: failed to rename temp file `{}` to `{}`:  {err}",
-                temppath.display(),
-                dest_file_path.display()
-            );
-            // As above: client already has the body; cache state is
-            // inconsistent.  Stay alive and skip DB records.
+            // commit() dropped the barrier and logged mismatch / verify-IO;
+            // log rename failures here. The body was already fully delivered
+            // to the client; this only leaves the cache without the file
+            // (the TempPath guard removes the temp file, future requests
+            // re-download). Report success so the connection stays alive and
+            // skip the DB Download/Delivery/Origin records.
+            if let integrity::CommitError::Rename(io_err) = &err {
+                metrics::CACHE_IO_FAILURE.increment();
+                error!(
+                    "splice proxy: failed to rename temp file `{}` to `{}`:  {}",
+                    temppath.display(),
+                    dest_file_path.display(),
+                    ErrorReport(io_err)
+                );
+            }
             return Ok(());
         }
     }

--- a/src/task_cleanup.rs
+++ b/src/task_cleanup.rs
@@ -22,8 +22,8 @@ use tokio::io::{AsyncBufRead, AsyncSeekExt as _, AsyncWriteExt as _, BufWriter};
 use crate::{
     AppState, ClientInfo, Never, ProxyCacheBody, RETENTION_TIME,
     cache_layout::{
-        CacheLayout, CachedFlavor, ConnectionDetails, SUBDIR_DISTS_BYHASH, SUBDIR_FLAT_BYHASH,
-        SUBDIR_TMP,
+        CacheLayout, CachedFlavor, ConnectionDetails, ResourceKind, SUBDIR_DISTS_BYHASH,
+        SUBDIR_FLAT_BYHASH, SUBDIR_TMP,
     },
     cache_metadata,
     config::{CacheHost, Config},
@@ -626,6 +626,24 @@ async fn try_fetch_packages_file<F>(
 where
     F: Fn(PackageFormat) -> String,
 {
+    // The resource kind drives integrity-registry lookup/ingestion: structured
+    // `dists/.../Packages*` is `Packages`; flat-repo `<root>/Packages*` is
+    // `FlatMetadata`. Match the dispatcher's `classify_request` so a cleanup
+    // re-fetch is classified identically to a client request.
+    let resource_kind = match layout {
+        CacheLayout::Dists => ResourceKind::Packages,
+        CacheLayout::Flat => ResourceKind::FlatMetadata,
+        CacheLayout::StructuredPool | CacheLayout::DistsByHash | CacheLayout::FlatByHash => {
+            // try_fetch_packages_file is only called with Dists or Flat above;
+            // a future caller passing a by-hash/pool layout is a logic bug.
+            error!(
+                "try_fetch_packages_file called with unexpected layout {layout:?}; \
+                 defaulting resource_kind to Packages"
+            );
+            ResourceKind::Packages
+        }
+    };
+
     let mut uri_buffer = String::with_capacity(base_uri.len() + 3);
     // Remember a representative missing-ish status to surface after every
     // format fails. AWS S3 returns 403 (not 404) for a missing object when
@@ -657,6 +675,7 @@ where
             debname: debname_for(pkgfmt),
             cached_flavor: CachedFlavor::Volatile,
             layout,
+            resource_kind,
         };
 
         let response = process_cache_request(conn_details, req, appstate.clone()).await;

--- a/src/web_interface.rs
+++ b/src/web_interface.rs
@@ -27,7 +27,7 @@ use crate::{
     database::{Database, MirrorStatEntry},
     database_task::DB_TASK_QUEUE_SENDER,
     deb_mirror::VALID_DEB_EXTENSIONS,
-    full_body, get_features, global_cache_quota, global_config,
+    full_body, get_features, global_cache_quota, global_checksum_registry, global_config,
     http_range::format_http_date,
     humanfmt::HumanFmt,
     hyper_conn::tunnel_limiter::active_tunnels,
@@ -1595,6 +1595,26 @@ fn build_metrics_html() -> String {
             ),
         );
     }
+    t.row_tip(
+        "Integrity Verified",
+        "Downloaded resources (pool .debs, by-hash files, Packages indices) whose content hash matched a known digest.",
+        metrics::CHECKSUM_VERIFIED.get(),
+    );
+    t.row_tip(
+        "Integrity Mismatch (rejected)",
+        "Resources rejected because their content hash did not match the expected digest. Non-zero indicates a corrupt or tampered upstream response.",
+        AlertNonzero(metrics::CHECKSUM_MISMATCH.get()),
+    );
+    t.row_tip(
+        "Integrity Unverified (no known digest)",
+        "Resources for which no expected digest was available in the registry; cached unverified (best-effort).",
+        metrics::CHECKSUM_UNVERIFIED.get(),
+    );
+    t.row_tip(
+        "Integrity Registry entries",
+        "In-memory checksum-registry entries (expected digests parsed from Packages/Release indices; lost on restart).",
+        global_checksum_registry().len(),
+    );
     {
         let status_2xx = metrics::CLIENT_STATUS_2XX.get();
         let status_200 = metrics::CLIENT_STATUS_200.get();


### PR DESCRIPTION
Before a finished download is renamed into the cache, check its content against the repository's own digests: by-hash files self-verify from the URL, while .deb (Pool) and Packages files are matched against an in-memory registry populated from streamed Release/Packages ingest. Wired into RenameBarrier::commit so no download backend can bypass it. Defence in depth only -- APT's client-side GPG check remains the root of trust -- and gated by verify_checksums (default on).