### PR TITLE
Throttle re-downloads of resources failing checksum verification

### DIFF
--- a/debian/apt-cacher-rs.conf
+++ b/debian/apt-cacher-rs.conf
@@ -157,3 +157,12 @@
 
 # Upper bound (entries) on the in-memory checksum registry.
 #verify_checksums_max_entries = 500000
+
+# Backoff window (seconds) applied to a resource after its download failed
+# checksum verification: further requests for it are rejected with 503
+# without contacting upstream. Doubles per consecutive failure up to
+# verify_checksums_throttle_cap; a verified download clears it. 0 disables.
+#verify_checksums_throttle_base = 30
+
+# Upper bound (seconds) on the exponential verification-failure backoff.
+#verify_checksums_throttle_cap = 3600

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,8 @@ const DEFAULT_UPSTREAM_TCP_NODELAY: bool = true;
 const DEFAULT_REJECT_PDIFF_REQUESTS: bool = true;
 const DEFAULT_VERIFY_CHECKSUMS: bool = true;
 const DEFAULT_VERIFY_CHECKSUMS_MAX_ENTRIES: NonZero<usize> = nonzero!(500_000);
+const DEFAULT_VERIFY_CHECKSUMS_THROTTLE_BASE: Duration = Duration::from_secs(30);
+const DEFAULT_VERIFY_CHECKSUMS_THROTTLE_CAP: Duration = Duration::from_hours(1);
 const DEFAULT_EXPERIMENTAL_PARALLEL_HACK_ENABLED: bool = false;
 const DEFAULT_EXPERIMENTAL_PARALLEL_HACK_MAXPARALLEL: Option<NonZero<usize>> = Some(nonzero!(3));
 const DEFAULT_EXPERIMENTAL_PARALLEL_HACK_STATUSCODE: StatusCode = StatusCode::TOO_MANY_REQUESTS;
@@ -831,6 +833,26 @@ pub(crate) struct Config {
     #[serde(default = "default_verify_checksums_max_entries")]
     pub(crate) verify_checksums_max_entries: NonZero<usize>,
 
+    /// Backoff window (in seconds) applied to a resource after its download
+    /// failed checksum verification: subsequent requests for it are rejected
+    /// with 503 without contacting upstream. The window doubles per
+    /// consecutive failure up to `verify_checksums_throttle_cap`; a
+    /// successfully verified download clears it. 0 disables the throttle.
+    /// Only effective when `verify_checksums` is enabled.
+    #[serde(
+        default = "default_verify_checksums_throttle_base",
+        deserialize_with = "from_secs_f64"
+    )]
+    pub(crate) verify_checksums_throttle_base: Duration,
+
+    /// Upper bound (in seconds) on the exponential verification-failure
+    /// backoff window.
+    #[serde(
+        default = "default_verify_checksums_throttle_cap",
+        deserialize_with = "from_secs_f64"
+    )]
+    pub(crate) verify_checksums_throttle_cap: Duration,
+
     #[serde(default = "default_experimental_parallel_hack_enabled")]
     pub(crate) experimental_parallel_hack_enabled: bool,
 
@@ -1097,6 +1119,14 @@ const fn default_verify_checksums() -> bool {
 
 const fn default_verify_checksums_max_entries() -> NonZero<usize> {
     DEFAULT_VERIFY_CHECKSUMS_MAX_ENTRIES
+}
+
+const fn default_verify_checksums_throttle_base() -> Duration {
+    DEFAULT_VERIFY_CHECKSUMS_THROTTLE_BASE
+}
+
+const fn default_verify_checksums_throttle_cap() -> Duration {
+    DEFAULT_VERIFY_CHECKSUMS_THROTTLE_CAP
 }
 
 const fn default_logstore_capacity() -> NonZero<usize> {
@@ -1708,6 +1738,37 @@ impl Config {
             ));
         }
 
+        if self.verify_checksums_throttle_cap < self.verify_checksums_throttle_base {
+            warnings.push(format!(
+                "verify_checksums_throttle_cap ({}s) is below verify_checksums_throttle_base ({}s); the cap will be raised to the base",
+                self.verify_checksums_throttle_cap.as_secs_f64(),
+                self.verify_checksums_throttle_base.as_secs_f64()
+            ));
+        }
+
+        if !self.verify_checksums {
+            // An explicit 0 means deliberately disabled -- no warning.
+            for (name, value, default) in [
+                (
+                    "verify_checksums_throttle_base",
+                    self.verify_checksums_throttle_base,
+                    DEFAULT_VERIFY_CHECKSUMS_THROTTLE_BASE,
+                ),
+                (
+                    "verify_checksums_throttle_cap",
+                    self.verify_checksums_throttle_cap,
+                    DEFAULT_VERIFY_CHECKSUMS_THROTTLE_CAP,
+                ),
+            ] {
+                if value != default && !value.is_zero() {
+                    warnings.push(format!(
+                        "{name} ({}s) has no effect while verify_checksums is disabled",
+                        value.as_secs_f64()
+                    ));
+                }
+            }
+        }
+
         if self.cache_directory.as_os_str().is_empty() {
             bail!("Invalid cache_directory value: must not be empty");
         }
@@ -2087,5 +2148,75 @@ mod test {
     fn verify_checksums_can_be_disabled() {
         let cfg: Config = toml::from_str("verify_checksums = false").expect("config parses");
         assert!(!cfg.verify_checksums);
+    }
+
+    #[test]
+    fn verify_throttle_defaults() {
+        let cfg: Config = toml::from_str("").expect("empty config parses");
+        assert_eq!(cfg.verify_checksums_throttle_base, Duration::from_secs(30));
+        assert_eq!(cfg.verify_checksums_throttle_cap, Duration::from_hours(1));
+    }
+
+    #[test]
+    fn verify_throttle_overrides_parse() {
+        let cfg: Config = toml::from_str(
+            "verify_checksums_throttle_base = 0.5\nverify_checksums_throttle_cap = 60",
+        )
+        .expect("config parses");
+        assert_eq!(
+            cfg.verify_checksums_throttle_base,
+            Duration::from_millis(500)
+        );
+        assert_eq!(cfg.verify_checksums_throttle_cap, Duration::from_mins(1));
+    }
+
+    #[test]
+    fn verify_throttle_cap_below_base_warns() {
+        let mut cfg: Config = toml::from_str(
+            "verify_checksums_throttle_base = 60\nverify_checksums_throttle_cap = 30",
+        )
+        .expect("config parses");
+        let warnings = cfg.validate().expect("config validates");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("the cap will be raised to the base")),
+            "expected cap-below-base warning, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn verify_throttle_set_while_verify_off_warns() {
+        let mut cfg: Config = toml::from_str(
+            "verify_checksums = false\nverify_checksums_throttle_base = 60\nverify_checksums_throttle_cap = 120",
+        )
+        .expect("config parses");
+        let warnings = cfg.validate().expect("config validates");
+        assert_eq!(
+            warnings
+                .iter()
+                .filter(|w| w.contains("has no effect while verify_checksums is disabled"))
+                .count(),
+            2,
+            "expected warnings for both throttle options, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn verify_throttle_defaults_or_zero_while_verify_off_do_not_warn() {
+        for toml_input in [
+            "verify_checksums = false",
+            "verify_checksums = false\nverify_checksums_throttle_base = 0\nverify_checksums_throttle_cap = 0",
+            "verify_checksums = false\nverify_checksums_throttle_base = 30\nverify_checksums_throttle_cap = 3600",
+        ] {
+            let mut cfg: Config = toml::from_str(toml_input).expect("config parses");
+            let warnings = cfg.validate().expect("config validates");
+            assert!(
+                !warnings
+                    .iter()
+                    .any(|w| w.contains("has no effect while verify_checksums is disabled")),
+                "unexpected warning for `{toml_input}`: {warnings:?}"
+            );
+        }
     }
 }

--- a/src/guards.rs
+++ b/src/guards.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
-use log::error;
+use log::{error, info};
 
 use crate::{
     ContentLength,
@@ -10,6 +10,8 @@ use crate::{
     cache_quota::QuotaReservation,
     config::CacheHost,
     deb_mirror::Mirror,
+    global_verify_throttle,
+    humanfmt::HumanFmt,
     integrity::{self, CommitError, RenamePlan},
     metrics,
 };
@@ -401,7 +403,30 @@ impl RenameBarrier {
     /// Arc -- benign for correctness, just slightly slower for the first
     /// read after cancellation.
     pub(crate) async fn commit(mut self, plan: RenamePlan) -> Result<(), CommitError> {
-        integrity::verify_and_rename(&plan).await?;
+        if let Err(err) = integrity::verify_and_rename(&plan).await {
+            // Arm the re-download throttle only on a genuine content
+            // mismatch; VerifyIo/Rename are transient local problems.
+            if matches!(err, CommitError::ChecksumMismatch) {
+                let data = self
+                    .data
+                    .as_ref()
+                    .expect("every sink consumes the instance");
+                if let Some((window, failures)) = global_verify_throttle().record_failure(
+                    &data.mirror,
+                    &data.debname,
+                    data.layout,
+                ) {
+                    info!(
+                        "Throttling downloads of {} from mirror {} for {} after checksum verification failure (consecutive failures: {failures})",
+                        data.debname,
+                        data.mirror,
+                        HumanFmt::Time(window),
+                    );
+                }
+            }
+            // `self.data` is still held: Drop runs the abort path.
+            return Err(err);
+        }
 
         // Verified and renamed. Finalise quota outside the lock, then take the
         // write lock briefly for the `Verifying -> Finished` status flip.
@@ -443,6 +468,7 @@ impl RenameBarrier {
                 meta,
             );
         }
+        global_verify_throttle().record_success(&data.mirror, &data.debname, data.layout);
         data.active_downloads
             .remove(&data.mirror, &data.debname, data.layout);
 

--- a/src/http_helpers.rs
+++ b/src/http_helpers.rs
@@ -142,6 +142,7 @@ pub(crate) async fn write_invalid_response(
     conn_action: ConnectionAction,
     status: StatusCode,
     msg: &'static str,
+    retry_after: Option<std::time::Duration>,
 ) -> std::io::Result<()> {
     let date = format_http_date();
     let content_length = msg.len();
@@ -150,6 +151,14 @@ pub(crate) async fn write_invalid_response(
         "Allow: GET\r\n"
     } else {
         ""
+    };
+
+    let retry_after = match retry_after {
+        Some(remaining) => {
+            let secs = u32::try_from(remaining.as_secs().saturating_add(1)).unwrap_or(u32::MAX);
+            format!("Retry-After: {secs}\r\n")
+        }
+        None => String::new(),
     };
 
     let response = format!(
@@ -162,6 +171,7 @@ pub(crate) async fn write_invalid_response(
          Content-Length: {content_length}\r\n\
          Accept-Ranges: bytes\r\n\
          {extra_headers}\
+         {retry_after}\
          \r\n\
          {msg}"
     );

--- a/src/hyper_conn.rs
+++ b/src/hyper_conn.rs
@@ -44,7 +44,7 @@ use crate::{
     database_task::{DatabaseCommand, DbCmdDelivery, DbCmdDownload, DbCmdOrigin, send_db_command},
     deb_mirror::Origin,
     error::{ErrorReport, MirrorDownloadRate, ProxyCacheError, UpstreamFetchError},
-    global_cache_quota, global_config,
+    full_body, global_cache_quota, global_config, global_verify_throttle,
     guards::{DownloadBarrier, InitBarrier},
     http_etag::{is_valid_etag, write_etag},
     http_last_modified::write_last_modified,
@@ -2261,6 +2261,38 @@ async fn serve_new_file(
             StatusCode::SERVICE_UNAVAILABLE,
             "Too many concurrent upstream downloads",
         );
+    }
+
+    // Cleanup probes bypass the throttle: they run once per 24h cycle and a
+    // 503 would hard-fail the index-fetch cascade; their commit outcome
+    // still records/clears throttle state.
+    if !conn_details.client.is_cleanup_synthetic()
+        && let Some(throttled) = global_verify_throttle().check(
+            &conn_details.mirror,
+            &conn_details.debname,
+            conn_details.layout,
+        )
+    {
+        warn_once_or_info!(
+            "Rejecting request for {} from client {}: recently failed checksum verification ({} consecutive failures), retry in {}",
+            conn_details.debname,
+            conn_details.client,
+            throttled.failures,
+            HumanFmt::Time(throttled.remaining)
+        );
+        metrics::DOWNLOAD_REJECTED_VERIFY_THROTTLE.increment();
+        let secs =
+            u32::try_from(throttled.remaining.as_secs().saturating_add(1)).unwrap_or(u32::MAX);
+        return Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .header(SERVER, APP_NAME)
+            .header(VIA, APP_VIA)
+            .header(DATE, format_http_date())
+            .header(CONNECTION, "keep-alive")
+            .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+            .header(RETRY_AFTER, HeaderValue::from(secs))
+            .body(full_body("Recently failed checksum verification"))
+            .expect("Response is valid");
     }
 
     let prefetched_upstream_metadata = match &cfstate {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ mod task_setup;
 mod tcp_cork_guard;
 mod uncacheables;
 mod utils;
+mod verify_throttle;
 mod web_interface;
 mod xattr_helpers;
 mod xz_stream;
@@ -592,6 +593,7 @@ struct RuntimeDetails {
     config: config::Config,
     cache_quota: cache_quota::CacheQuota,
     checksum_registry: integrity::ChecksumRegistry,
+    verify_throttle: verify_throttle::VerifyThrottle,
 }
 
 #[derive(Clone, Debug)]
@@ -665,6 +667,15 @@ pub(crate) fn global_checksum_registry() -> &'static integrity::ChecksumRegistry
         .get()
         .expect("Global was initialized in main()")
         .checksum_registry
+}
+
+#[must_use]
+#[inline]
+pub(crate) fn global_verify_throttle() -> &'static verify_throttle::VerifyThrottle {
+    &RUNTIMEDETAILS
+        .get()
+        .expect("Global was initialized in main()")
+        .verify_throttle
 }
 
 #[cfg(feature = "tls_rustls")]
@@ -830,12 +841,24 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let checksum_registry = integrity::ChecksumRegistry::new(config.verify_checksums_max_entries);
 
+    // Zeroed base when verification is off: the throttle can never arm, so
+    // no call site needs to consult `verify_checksums`.
+    let verify_throttle = verify_throttle::VerifyThrottle::new(
+        if config.verify_checksums {
+            config.verify_checksums_throttle_base
+        } else {
+            Duration::ZERO
+        },
+        config.verify_checksums_throttle_cap,
+    );
+
     RUNTIMEDETAILS
         .set(RuntimeDetails {
             start_time: time::OffsetDateTime::now_utc(),
             cache_quota: cache_quota::CacheQuota::new(0, config.disk_quota),
             config,
             checksum_registry,
+            verify_throttle,
         })
         .expect("Initial set in main() should succeed");
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -316,6 +316,9 @@ pub(crate) static DOWNLOAD_REJECTED_QUOTA: Counter = Counter::new();
 /// Downloads rejected because the upstream-declared object size exceeded the
 /// configured `max_object_size`.
 pub(crate) static DOWNLOAD_REJECTED_OVERSIZE: Counter = Counter::new();
+/// Requests rejected with 503 because the resource recently failed checksum
+/// verification and is inside its backoff window (upstream not contacted).
+pub(crate) static DOWNLOAD_REJECTED_VERIFY_THROTTLE: Counter = Counter::new();
 
 /// Permanent-file cache lookup found a usable file.
 pub(crate) static CACHE_HITS: Counter = Counter::new();

--- a/src/sendfile_conn.rs
+++ b/src/sendfile_conn.rs
@@ -169,6 +169,7 @@ pub(crate) async fn handle_sendfile_connection(
                     ConnectionAction::Close,
                     StatusCode::BAD_REQUEST,
                     "Error reading request headers",
+                    None,
                 )
                 .await;
                 return;
@@ -212,6 +213,7 @@ pub(crate) async fn handle_sendfile_connection(
                     ConnectionAction::Close,
                     status,
                     msg,
+                    None,
                 )
                 .await
                 {
@@ -229,7 +231,8 @@ pub(crate) async fn handle_sendfile_connection(
                 msg,
             } => {
                 if let Err(err) =
-                    write_invalid_response(&stream, conn_version, conn_action, status, msg).await
+                    write_invalid_response(&stream, conn_version, conn_action, status, msg, None)
+                        .await
                 {
                     info!(
                         "Failed to write rejection response to client {client}:  {}",

--- a/src/splice_conn.rs
+++ b/src/splice_conn.rs
@@ -72,7 +72,7 @@ use crate::{
     SchemeKey, SchemeKeyRef, VOLATILE_UNKNOWN_CONTENT_LENGTH_UPPER,
     active_downloads::{ActiveDownloadStatus, OriginateOutcome},
     cache_metadata, client_counter, content_type_for_cached_file, global_cache_quota,
-    global_config, metrics,
+    global_config, global_verify_throttle, metrics,
     permitted_host_cache::is_host_allowed_cached,
     static_assert, warn_on_content_type_mismatch, warn_once_or_debug, warn_once_or_info,
 };
@@ -4030,7 +4030,7 @@ async fn serve_volatile_304_via_sendfile(
         | SendfileResult::ClientError
         | SendfileResult::AfterHeaderError => Ok(()),
         SendfileResult::Invalid { status, msg } => {
-            write_invalid_response(client_stream, conn_version, conn_action, status, msg)
+            write_invalid_response(client_stream, conn_version, conn_action, status, msg, None)
                 .await
                 .map_err(|err| SpliceProxyError::Client(err, invalid_tag))?;
             Ok(())
@@ -4066,6 +4066,38 @@ async fn splice_proxy_drive(
         &conn_details.debname,
         conn_details.layout,
     );
+
+    // Cleanup probes bypass the throttle: they run once per 24h cycle and a
+    // 503 would hard-fail the index-fetch cascade; their commit outcome
+    // still records/clears throttle state. (Only the hyper gate is reachable
+    // by cleanup today; kept here for parallel-path symmetry.)
+    if !conn_details.client.is_cleanup_synthetic()
+        && let Some(throttled) = global_verify_throttle().check(
+            &conn_details.mirror,
+            &conn_details.debname,
+            conn_details.layout,
+        )
+    {
+        warn_once_or_info!(
+            "splice proxy: rejecting request for {} from client {}: recently failed checksum verification ({} consecutive failures), retry in {}",
+            conn_details.debname,
+            conn_details.client,
+            throttled.failures,
+            HumanFmt::Time(throttled.remaining)
+        );
+        metrics::DOWNLOAD_REJECTED_VERIFY_THROTTLE.increment();
+        write_invalid_response(
+            client_stream,
+            conn_version,
+            conn_action,
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Recently failed checksum verification",
+            Some(throttled.remaining),
+        )
+        .await
+        .map_err(|err| SpliceProxyError::Client(err, "verify-throttle 503"))?;
+        return Ok(());
+    }
 
     let mirror = &conn_details.mirror;
     let host_authority = mirror.format_authority();
@@ -4225,6 +4257,7 @@ async fn splice_proxy_drive(
                     conn_action,
                     StatusCode::BAD_GATEWAY,
                     "no Content-Length",
+                    None,
                 )
                 .await
                 .map_err(|err| SpliceProxyError::Client(err, "kTLS no-CL 502"))?;
@@ -4702,6 +4735,7 @@ async fn splice_proxy_drive(
             conn_action,
             StatusCode::BAD_GATEWAY,
             "Unsolicited 206",
+            None,
         )
         .await
         .map_err(|err| SpliceProxyError::Client(err, "unsolicited 206 502"))?;
@@ -4741,6 +4775,7 @@ async fn splice_proxy_drive(
                         conn_action,
                         StatusCode::BAD_GATEWAY,
                         "Inconsistent Content-Range",
+                        None,
                     )
                     .await
                     .map_err(|err| {
@@ -4779,6 +4814,7 @@ async fn splice_proxy_drive(
                     conn_action,
                     StatusCode::BAD_GATEWAY,
                     "unexpected Content-Range",
+                    None,
                 )
                 .await
                 .map_err(|err| SpliceProxyError::Client(err, "unexpected Content-Range 502"))?;
@@ -4824,6 +4860,7 @@ async fn splice_proxy_drive(
                 conn_action,
                 StatusCode::BAD_GATEWAY,
                 "no Content-Length",
+                None,
             )
             .await
             .map_err(|err| SpliceProxyError::Client(err, "no-CL 502"))?;
@@ -4848,6 +4885,7 @@ async fn splice_proxy_drive(
             conn_action,
             StatusCode::BAD_GATEWAY,
             "zero total file size",
+            None,
         )
         .await
         .map_err(|err| SpliceProxyError::Client(err, "zero total-size 502"))?;
@@ -4871,6 +4909,7 @@ async fn splice_proxy_drive(
             conn_action,
             StatusCode::BAD_GATEWAY,
             "upstream resource too large",
+            None,
         )
         .await
         .map_err(|err| SpliceProxyError::Client(err, "oversize 502"))?;
@@ -4890,6 +4929,7 @@ async fn splice_proxy_drive(
             conn_action,
             StatusCode::BAD_GATEWAY,
             "zero body Content-Length",
+            None,
         )
         .await
         .map_err(|err| SpliceProxyError::Client(err, "zero body-CL 502"))?;
@@ -4995,6 +5035,7 @@ async fn splice_proxy_drive(
                 conn_action,
                 StatusCode::SERVICE_UNAVAILABLE,
                 "Disk quota reached",
+                None,
             )
             .await
             .map_err(|err| SpliceProxyError::Client(err, "quota 503"))?;
@@ -5023,6 +5064,7 @@ async fn splice_proxy_drive(
                     conn_action,
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Cache Access Failure",
+                    None,
                 )
                 .await
                 .map_err(|err| SpliceProxyError::Client(err, "partial-size mismatch 500"))?;
@@ -5109,6 +5151,7 @@ async fn splice_proxy_drive(
             conn_action,
             StatusCode::BAD_GATEWAY,
             "body Content-Length mismatch",
+            None,
         )
         .await
         .map_err(|err| SpliceProxyError::Client(err, "body-CL mismatch 502"))?;
@@ -5135,6 +5178,7 @@ async fn splice_proxy_drive(
                 conn_action,
                 StatusCode::BAD_GATEWAY,
                 "body Content-Length mismatch",
+                None,
             )
             .await
             .map_err(|err| SpliceProxyError::Client(err, "kTLS extra-body mismatch 502"))?;
@@ -6111,6 +6155,7 @@ async fn handle_volatile_buffered_download(
             conn_action,
             StatusCode::BAD_GATEWAY,
             "zero-length body",
+            None,
         )
         .await
         .map_err(|err| SpliceProxyError::Client(err, "volatile zero-body 502"))?;
@@ -6163,6 +6208,7 @@ async fn handle_volatile_buffered_download(
                 conn_action,
                 StatusCode::SERVICE_UNAVAILABLE,
                 "Disk quota reached",
+                None,
             )
             .await
             .map_err(|err| SpliceProxyError::Client(err, "volatile quota 503"))?;

--- a/src/verify_throttle.rs
+++ b/src/verify_throttle.rs
@@ -1,0 +1,515 @@
+//! Backoff for resources that repeatedly fail checksum verification.
+//!
+//! A download failing [`crate::integrity`] verification is discarded and
+//! never cached, so a client re-requesting the same resource would make the
+//! proxy re-download it from upstream on every request. [`VerifyThrottle`]
+//! records each mismatch and lets the origination gates reject further
+//! requests for that resource with 503 -- without contacting upstream --
+//! for an exponentially growing window (doubling per consecutive failure,
+//! capped). A successful commit clears the entry.
+//!
+//! Keyed like `active_downloads`: `(Mirror, debname, CacheLayout)`. Two
+//! aliases of the same physical mirror therefore throttle independently --
+//! the same granularity trade-off `ActiveDownloadKey` makes.
+//!
+//! Time is tracked on `coarsetime` (the crate-preferred clock); its ~1ms
+//! resolution is irrelevant for second-scale backoff windows. The public
+//! API speaks `std::time::Duration` (config input, log output).
+
+use coarsetime::{Duration, Instant};
+use hashbrown::{Equivalent, HashMap};
+
+use crate::cache_layout::CacheLayout;
+use crate::deb_mirror::Mirror;
+
+/// Soft cap on the entry count. Every entry requires an actual upstream
+/// download that failed verification, so realistic workloads stay tiny;
+/// the cap purely bounds memory if an upstream serves endless garbage.
+const MAX_THROTTLE_ENTRIES: usize = 256;
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct ThrottleKey {
+    mirror: Mirror,
+    debname: String,
+    layout: CacheLayout,
+}
+
+#[derive(Hash)]
+struct ThrottleKeyRef<'a> {
+    mirror: &'a Mirror,
+    debname: &'a str,
+    layout: CacheLayout,
+}
+
+impl Equivalent<ThrottleKey> for ThrottleKeyRef<'_> {
+    fn equivalent(&self, key: &ThrottleKey) -> bool {
+        let &Self {
+            mirror,
+            debname,
+            layout,
+        } = self;
+        let ThrottleKey {
+            mirror: kmirror,
+            debname: kdebname,
+            layout: klayout,
+        } = key;
+        mirror == kmirror && debname == kdebname && layout == *klayout
+    }
+}
+
+#[derive(Debug)]
+struct ThrottleEntry {
+    /// Consecutive verification failures for this resource (>= 1).
+    failures: u32,
+    /// When the current backoff window ends.
+    until: Instant,
+}
+
+/// Snapshot returned by [`VerifyThrottle::check`] for a throttled resource;
+/// carries the context the rejection log line needs.
+#[derive(Debug)]
+pub(crate) struct Throttled {
+    pub(crate) remaining: std::time::Duration,
+    pub(crate) failures: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct VerifyThrottle {
+    map: parking_lot::RwLock<HashMap<ThrottleKey, ThrottleEntry>>,
+    /// Window after the first failure; zero disables the whole feature.
+    base: Duration,
+    /// Upper bound on the window. Doubles as the streak-reset TTL: a
+    /// failure arriving more than `cap` after the previous window ended
+    /// starts a fresh streak at `base`.
+    cap: Duration,
+}
+
+impl VerifyThrottle {
+    #[must_use]
+    pub(crate) fn new(base: std::time::Duration, cap: std::time::Duration) -> Self {
+        let base = Duration::from(base);
+        let cap = Duration::from(cap);
+        Self {
+            map: parking_lot::RwLock::new(HashMap::new()),
+            base,
+            cap: cap.max(base),
+        }
+    }
+
+    fn is_disabled(&self) -> bool {
+        self.base.as_ticks() == 0
+    }
+
+    /// Whether the resource is inside its backoff window.
+    #[must_use]
+    pub(crate) fn check(
+        &self,
+        mirror: &Mirror,
+        debname: &str,
+        layout: CacheLayout,
+    ) -> Option<Throttled> {
+        self.check_at(mirror, debname, layout, Instant::now())
+    }
+
+    fn check_at(
+        &self,
+        mirror: &Mirror,
+        debname: &str,
+        layout: CacheLayout,
+        now: Instant,
+    ) -> Option<Throttled> {
+        if self.is_disabled() {
+            return None;
+        }
+        let key = ThrottleKeyRef {
+            mirror,
+            debname,
+            layout,
+        };
+        let (failures, until) = self
+            .map
+            .read()
+            .get(&key)
+            .map(|entry| (entry.failures, entry.until))?;
+        (now < until).then(|| Throttled {
+            remaining: until.duration_since(now).into(),
+            failures,
+        })
+    }
+
+    /// Record a checksum-verification failure and arm/extend the backoff
+    /// window. Returns the new `(window, consecutive_failures)` for the
+    /// caller's log line, or `None` when the throttle is disabled.
+    pub(crate) fn record_failure(
+        &self,
+        mirror: &Mirror,
+        debname: &str,
+        layout: CacheLayout,
+    ) -> Option<(std::time::Duration, u32)> {
+        self.record_failure_at(mirror, debname, layout, Instant::now())
+    }
+
+    fn record_failure_at(
+        &self,
+        mirror: &Mirror,
+        debname: &str,
+        layout: CacheLayout,
+        now: Instant,
+    ) -> Option<(std::time::Duration, u32)> {
+        if self.is_disabled() {
+            return None;
+        }
+        let key = ThrottleKeyRef {
+            mirror,
+            debname,
+            layout,
+        };
+        let mut map = self.map.write();
+
+        let failures = match map.get(&key) {
+            // A failure within the streak-reset TTL of the previous
+            // window continues the streak; a later one starts over.
+            Some(entry) if now <= entry.until + self.cap => entry.failures.saturating_add(1),
+            _ => 1,
+        };
+        if !map.contains_key(&key) && map.len() >= MAX_THROTTLE_ENTRIES {
+            // Best-effort cap: purge entries whose streak already reset,
+            // then clear outright rather than implement proper LRU.
+            let cap = self.cap;
+            map.retain(|_, entry| now <= entry.until + cap);
+            if map.len() >= MAX_THROTTLE_ENTRIES {
+                map.clear();
+            }
+        }
+
+        let window = self
+            .base
+            .saturating_mul(2u32.saturating_pow(failures - 1))
+            .min(self.cap);
+        map.insert(
+            ThrottleKey {
+                mirror: mirror.clone(),
+                debname: debname.to_owned(),
+                layout,
+            },
+            ThrottleEntry {
+                failures,
+                until: now + window,
+            },
+        );
+        drop(map);
+        Some((window.into(), failures))
+    }
+
+    /// Clear the entry after a successful commit -- the resource verified,
+    /// so any earlier failures are stale.
+    pub(crate) fn record_success(&self, mirror: &Mirror, debname: &str, layout: CacheLayout) {
+        if self.map.read().is_empty() {
+            return;
+        }
+        let key = ThrottleKeyRef {
+            mirror,
+            debname,
+            layout,
+        };
+        self.map.write().remove(&key);
+    }
+
+    /// Number of resources currently inside a backoff window (dashboard
+    /// gauge; expired-but-not-yet-purged streak entries are excluded).
+    #[must_use]
+    pub(crate) fn active_len(&self) -> usize {
+        self.active_len_at(Instant::now())
+    }
+
+    fn active_len_at(&self, now: Instant) -> usize {
+        self.map
+            .read()
+            .values()
+            .filter(|entry| now < entry.until)
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ClientHost;
+    use crate::deb_mirror::MirrorKind;
+
+    const BASE_SECS: u64 = 30;
+    const CAP_SECS: u64 = 3600;
+    const BASE: Duration = Duration::from_secs(BASE_SECS);
+    const CAP: Duration = Duration::from_secs(CAP_SECS);
+    const SECOND: Duration = Duration::from_secs(1);
+
+    fn std_secs(secs: u64) -> std::time::Duration {
+        std::time::Duration::from_secs(secs)
+    }
+
+    fn test_mirror() -> Mirror {
+        Mirror::new(
+            ClientHost::new("deb.debian.org".to_string()).expect("valid host"),
+            None,
+            String::new(),
+            MirrorKind::Structured,
+        )
+    }
+
+    fn throttle() -> VerifyThrottle {
+        VerifyThrottle::new(std_secs(BASE_SECS), std_secs(CAP_SECS))
+    }
+
+    #[test]
+    fn unknown_resource_is_unthrottled() {
+        let t = throttle();
+        let mirror = test_mirror();
+        assert!(
+            t.check_at(
+                &mirror,
+                "foo.deb",
+                CacheLayout::StructuredPool,
+                Instant::now()
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn first_failure_throttles_for_base_then_expires() {
+        let t = throttle();
+        let mirror = test_mirror();
+        let t0 = Instant::now();
+
+        let (window, failures) = t
+            .record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, t0)
+            .expect("throttle enabled");
+        assert_eq!(window, std_secs(BASE_SECS));
+        assert_eq!(failures, 1);
+
+        let throttled = t
+            .check_at(
+                &mirror,
+                "foo.deb",
+                CacheLayout::StructuredPool,
+                t0 + Duration::from_secs(BASE_SECS / 2),
+            )
+            .expect("inside the window");
+        assert_eq!(throttled.failures, 1);
+        assert_eq!(throttled.remaining, std_secs(BASE_SECS / 2));
+
+        assert!(
+            t.check_at(&mirror, "foo.deb", CacheLayout::StructuredPool, t0 + BASE)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn consecutive_failures_double_up_to_cap() {
+        let t = throttle();
+        let mirror = test_mirror();
+        let mut now = Instant::now();
+
+        let mut expected = vec![];
+        let mut secs = BASE_SECS;
+        for _ in 0..10 {
+            expected.push(secs.min(CAP_SECS));
+            secs *= 2;
+        }
+
+        for want in expected {
+            let (window, _) = t
+                .record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, now)
+                .expect("throttle enabled");
+            assert_eq!(window, std_secs(want));
+            now += SECOND;
+        }
+    }
+
+    #[test]
+    fn success_clears_entry_and_resets_streak() {
+        let t = throttle();
+        let mirror = test_mirror();
+        let t0 = Instant::now();
+
+        t.record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, t0);
+        t.record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, t0 + SECOND);
+        t.record_success(&mirror, "foo.deb", CacheLayout::StructuredPool);
+        assert!(
+            t.check_at(&mirror, "foo.deb", CacheLayout::StructuredPool, t0 + SECOND)
+                .is_none()
+        );
+
+        let (window, failures) = t
+            .record_failure_at(
+                &mirror,
+                "foo.deb",
+                CacheLayout::StructuredPool,
+                t0 + SECOND * 2,
+            )
+            .expect("throttle enabled");
+        assert_eq!(window, std_secs(BASE_SECS));
+        assert_eq!(failures, 1);
+    }
+
+    #[test]
+    fn streak_resets_after_ttl() {
+        let t = throttle();
+        let mirror = test_mirror();
+        let t0 = Instant::now();
+
+        t.record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, t0);
+        let (window, failures) = t
+            .record_failure_at(
+                &mirror,
+                "foo.deb",
+                CacheLayout::StructuredPool,
+                t0 + BASE + CAP + SECOND,
+            )
+            .expect("throttle enabled");
+        assert_eq!(window, std_secs(BASE_SECS));
+        assert_eq!(failures, 1);
+    }
+
+    #[test]
+    fn streak_survives_window_expiry_within_ttl() {
+        let t = throttle();
+        let mirror = test_mirror();
+        let t0 = Instant::now();
+
+        t.record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, t0);
+        // Window (base) expired, but the streak-reset TTL (cap) has not.
+        let (window, failures) = t
+            .record_failure_at(
+                &mirror,
+                "foo.deb",
+                CacheLayout::StructuredPool,
+                t0 + BASE + SECOND,
+            )
+            .expect("throttle enabled");
+        assert_eq!(window, std_secs(2 * BASE_SECS));
+        assert_eq!(failures, 2);
+    }
+
+    #[test]
+    fn zero_base_disables() {
+        let t = VerifyThrottle::new(std::time::Duration::ZERO, std_secs(CAP_SECS));
+        let mirror = test_mirror();
+        let now = Instant::now();
+
+        assert!(
+            t.record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, now)
+                .is_none()
+        );
+        assert!(t.map.read().is_empty());
+        assert!(
+            t.check_at(&mirror, "foo.deb", CacheLayout::StructuredPool, now)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn cap_below_base_is_clamped() {
+        let t = VerifyThrottle::new(std_secs(BASE_SECS), std_secs(1));
+        let mirror = test_mirror();
+        let now = Instant::now();
+
+        let (window, _) = t
+            .record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, now)
+            .expect("throttle enabled");
+        assert_eq!(window, std_secs(BASE_SECS));
+        let (window, _) = t
+            .record_failure_at(
+                &mirror,
+                "foo.deb",
+                CacheLayout::StructuredPool,
+                now + SECOND,
+            )
+            .expect("throttle enabled");
+        assert_eq!(
+            window,
+            std_secs(BASE_SECS),
+            "clamped cap bounds the doubled window"
+        );
+    }
+
+    #[test]
+    fn bounding_purges_expired_streaks_then_clears() {
+        let t = throttle();
+        let mirror = test_mirror();
+        let t0 = Instant::now();
+
+        for i in 0..MAX_THROTTLE_ENTRIES {
+            t.record_failure_at(
+                &mirror,
+                &format!("pkg{i}.deb"),
+                CacheLayout::StructuredPool,
+                t0,
+            );
+        }
+        assert_eq!(t.map.read().len(), MAX_THROTTLE_ENTRIES);
+
+        // All existing streaks are past their reset TTL: the new insert
+        // purges them instead of clearing.
+        let later = t0 + BASE + CAP + SECOND;
+        t.record_failure_at(&mirror, "fresh.deb", CacheLayout::StructuredPool, later);
+        assert_eq!(t.map.read().len(), 1);
+
+        for i in 0..MAX_THROTTLE_ENTRIES - 1 {
+            t.record_failure_at(
+                &mirror,
+                &format!("live{i}.deb"),
+                CacheLayout::StructuredPool,
+                later,
+            );
+        }
+        assert_eq!(t.map.read().len(), MAX_THROTTLE_ENTRIES);
+
+        // All entries live: cap-and-clear, leaving only the new insert.
+        t.record_failure_at(&mirror, "over.deb", CacheLayout::StructuredPool, later);
+        assert_eq!(t.map.read().len(), 1);
+        assert!(
+            t.check_at(&mirror, "over.deb", CacheLayout::StructuredPool, later)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn keys_discriminate_mirror_and_layout() {
+        let t = throttle();
+        let mirror = test_mirror();
+        let other_mirror = Mirror::new(
+            ClientHost::new("archive.ubuntu.com".to_string()).expect("valid host"),
+            None,
+            String::new(),
+            MirrorKind::Structured,
+        );
+        let now = Instant::now();
+
+        t.record_failure_at(&mirror, "foo.deb", CacheLayout::StructuredPool, now);
+        assert!(
+            t.check_at(&other_mirror, "foo.deb", CacheLayout::StructuredPool, now)
+                .is_none()
+        );
+        assert!(
+            t.check_at(&mirror, "foo.deb", CacheLayout::Flat, now)
+                .is_none()
+        );
+        assert!(
+            t.check_at(&mirror, "foo.deb", CacheLayout::StructuredPool, now)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn active_len_counts_only_live_windows() {
+        let t = throttle();
+        let mirror = test_mirror();
+        let t0 = Instant::now();
+
+        t.record_failure_at(&mirror, "a.deb", CacheLayout::StructuredPool, t0);
+        t.record_failure_at(&mirror, "b.deb", CacheLayout::StructuredPool, t0);
+        assert_eq!(t.active_len_at(t0 + SECOND), 2);
+        assert_eq!(t.active_len_at(t0 + BASE), 0);
+    }
+}

--- a/src/web_interface.rs
+++ b/src/web_interface.rs
@@ -29,6 +29,7 @@ use crate::{
     database_task::DB_TASK_QUEUE_SENDER,
     deb_mirror::VALID_DEB_EXTENSIONS,
     full_body, get_features, global_cache_quota, global_checksum_registry, global_config,
+    global_verify_throttle,
     http_range::format_http_date,
     humanfmt::HumanFmt,
     hyper_conn::tunnel_limiter::active_tunnels,
@@ -1615,6 +1616,11 @@ fn build_metrics_html() -> String {
         "In-memory checksum-registry entries (expected digests parsed from Packages/Release indices; lost on restart).",
         global_checksum_registry().len(),
     );
+    t.row_tip(
+        "Integrity Throttled resources",
+        "Resources currently rejected with 503 because a recent download failed checksum verification (exponential backoff; cleared by a successfully verified download).",
+        WarnNonzero(global_verify_throttle().active_len() as u64),
+    );
     {
         let status_2xx = metrics::CLIENT_STATUS_2XX.get();
         let status_200 = metrics::CLIENT_STATUS_200.get();
@@ -1678,14 +1684,15 @@ fn build_metrics_html() -> String {
         );
     }
     t.row_tip(
-        "Rejected Requests (pdiff / unsafe path / quota hit / oversize)",
-        "Client requests rejected before serving: pdiff requests, requests with unsafe paths, downloads denied because the configured disk quota is exhausted, and downloads rejected because the upstream object size exceeded max_object_size.",
+        "Rejected Requests (pdiff / unsafe path / quota hit / oversize / verify-throttled)",
+        "Client requests rejected before serving: pdiff requests, requests with unsafe paths, downloads denied because the configured disk quota is exhausted, downloads rejected because the upstream object size exceeded max_object_size, and downloads rejected because the resource recently failed checksum verification.",
         format_args!(
-            "{} / {} / {} / {}",
+            "{} / {} / {} / {} / {}",
             metrics::PDIFF_REJECTED.get(),
             WarnNonzero(metrics::UNSAFE_PATH_REJECTED.get()),
             WarnNonzero(metrics::DOWNLOAD_REJECTED_QUOTA.get()),
-            WarnNonzero(metrics::DOWNLOAD_REJECTED_OVERSIZE.get())
+            WarnNonzero(metrics::DOWNLOAD_REJECTED_OVERSIZE.get()),
+            WarnNonzero(metrics::DOWNLOAD_REJECTED_VERIFY_THROTTLE.get())
         ),
     );
     t.row_tip(


### PR DESCRIPTION
A download failing verification is discarded, so a client re-requesting the same resource re-downloaded it from upstream on every request. Record mismatches in a per-resource map and reject further requests with 503 for an exponentially growing window (base 30s, doubling per consecutive failure, capped at 1h, both configurable); a successfully verified download clears the entry.