### PR TITLE
Replace simplelog with tracing for non-blocking log file writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,6 @@ dependencies = [
  "scopeguard",
  "serde",
  "sha2 0.11.0",
- "simplelog",
  "smallvec",
  "sqlx",
  "tempfile",
@@ -116,6 +115,10 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "toml",
+ "tracing",
+ "tracing-appender",
+ "tracing-log",
+ "tracing-subscriber",
  "urlencoding",
  "webpki-roots",
  "xattr",
@@ -481,6 +484,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1404,6 +1416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,15 +1456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1880,6 +1892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,17 +1921,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simplelog"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
-dependencies = [
- "log",
- "termcolor",
- "time",
-]
 
 [[package]]
 name = "slab"
@@ -2145,6 +2155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,15 +2217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,15 +2237,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -2422,6 +2436,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2466,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2515,6 +2566,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2611,15 +2668,6 @@ name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ tokio-rustls = { version = "0.26", optional = true }
 scopeguard = "1.2.0"
 serde = "1.0.197"
 sha2 = "0.11"
-simplelog = "0.12.1"
 smallvec = { version = "1.15", features = ["const_generics", "union"] }
 sqlx = { version = "0.9", default-features = false, features = [
     "macros",
@@ -64,10 +63,14 @@ sqlx = { version = "0.9", default-features = false, features = [
     "runtime-tokio",
     "sqlite",
 ] }
-time = { version = "0.3.47", features = ["parsing"] }
+time = { version = "0.3.47", features = ["formatting", "macros", "parsing"] }
 tokio = { version = "1.36.0", features = ["macros", "parking_lot", "rt-multi-thread", "signal"] }
 tokio-util = { version = "0.7.10", features = ["io-util"] }
 toml = "1.0.3"
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-log = "0.2"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "registry", "std", "ansi"] }
 urlencoding = "2.1.3"
 webpki-roots = { version = "1.0.7", optional = true }
 xattr = "1.6.1"

--- a/src/cache_layout.rs
+++ b/src/cache_layout.rs
@@ -54,7 +54,7 @@ use std::{
     string::FromUtf8Error,
 };
 
-use log::trace;
+use tracing::trace;
 
 use crate::{
     ClientInfo,

--- a/src/cache_quota.rs
+++ b/src/cache_quota.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, num::NonZero, sync::Arc};
 
-use log::{error, trace, warn};
+use tracing::{error, trace, warn};
 
 use crate::{ContentLength, metrics};
 

--- a/src/cleanup/engine.rs
+++ b/src/cleanup/engine.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 
 use coarsetime::Clock;
 use hashbrown::HashMap;
-use log::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     AppState, RETENTION_TIME,

--- a/src/cleanup/mod.rs
+++ b/src/cleanup/mod.rs
@@ -23,7 +23,7 @@ use std::{
 use coarsetime::Instant;
 use futures_util::StreamExt as _;
 use hashbrown::HashMap;
-use log::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     AppState, cache_layout::CacheLayout, cache_metadata, config::CacheHost,

--- a/src/cleanup/model.rs
+++ b/src/cleanup/model.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use http::StatusCode;
-use log::trace;
+use tracing::trace;
 
 use crate::RETENTION_TIME;
 use crate::cache_layout::{

--- a/src/cleanup/packages.rs
+++ b/src/cleanup/packages.rs
@@ -5,9 +5,9 @@ use bytes::Buf as _;
 use hashbrown::HashMap;
 use http::{Method, Request, Response, StatusCode, header::CACHE_CONTROL};
 use http_body_util::{BodyExt as _, Empty};
-use log::{debug, error, warn};
 use memfd::MemfdOptions;
 use tokio::io::{AsyncBufRead, AsyncSeekExt as _, AsyncWriteExt as _, BufWriter};
+use tracing::{debug, error, warn};
 
 use crate::{
     AppState, ClientInfo, Never, ProxyCacheBody,

--- a/src/cleanup/partials.rs
+++ b/src/cleanup/partials.rs
@@ -2,7 +2,7 @@ use std::io::ErrorKind;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
 
-use log::{debug, error};
+use tracing::{debug, error};
 
 use crate::metrics;
 

--- a/src/cleanup/refs.rs
+++ b/src/cleanup/refs.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use coarsetime::Clock;
 use hashbrown::HashSet;
-use log::{debug, error, warn};
+use tracing::{debug, error, warn};
 
 use crate::cache_layout::CacheLayout;
 use crate::database::MirrorEntry;

--- a/src/cleanup/scan.rs
+++ b/src/cleanup/scan.rs
@@ -2,7 +2,7 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use hashbrown::HashMap;
-use log::{debug, error, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use crate::cleanup::engine::{Candidate, SpanClass};
 use crate::deb_mirror::{is_deb_package, is_strict_path_descendant, path_starts_with_segment};

--- a/src/cleanup/sweep.rs
+++ b/src/cleanup/sweep.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::time::{Duration, SystemTime};
 
 use hashbrown::HashMap;
-use log::{debug, error, warn};
+use tracing::{debug, error, warn};
 
 use crate::cache_layout::CacheLayout;
 use crate::deb_mirror::{Mirror, is_deb_package};

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,8 +11,8 @@ use std::{
 use anyhow::{Context as _, anyhow, bail};
 use http::StatusCode;
 use ipnet::IpNet;
-use log::LevelFilter;
 use serde::{Deserialize, Deserializer};
+use tracing::level_filters::LevelFilter;
 
 use crate::VOLATILE_UNKNOWN_CONTENT_LENGTH_UPPER;
 use crate::nonzero;
@@ -33,7 +33,7 @@ const DEFAULT_HTTPS_TUNNEL_ENABLED: bool = true;
 const DEFAULT_HTTPS_TUNNEL_ALLOWED_PORTS: [NonZero<u16>; 1] = [nonzero!(443)];
 const DEFAULT_HTTPS_TUNNEL_MAX_CONNECTIONS_PER_CLIENT: Option<NonZero<usize>> = Some(nonzero!(10));
 const DEFAULT_MAX_CONNECTIONS_PER_CLIENT_IP: Option<NonZero<usize>> = None;
-const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Info;
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::INFO;
 const DEFAULT_LOG_DESTINATION: LogDestination = LogDestination::Console;
 const DEFAULT_LOGSTORE_CAPACITY: NonZero<usize> = nonzero!(100);
 const DEFAULT_MIN_DOWNLOAD_RATE: Option<NonZero<usize>> = Some(nonzero!(10000)); // 10 kB/s

--- a/src/database.rs
+++ b/src/database.rs
@@ -7,11 +7,11 @@ use std::{
     time::Duration,
 };
 
-use log::{LevelFilter, debug, info, trace, warn};
 use sqlx::{
     ConnectOptions as _, Error, Executor as _, Pool, Sqlite, SqliteConnection, SqlitePool, query,
     query_as, sqlite::SqliteConnectOptions,
 };
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     CLEANUP_CLIENT_ADDR,
@@ -402,8 +402,10 @@ impl Database {
 
         let opts = SqliteConnectOptions::from_str(&url)?
             .create_if_missing(true)
-            .log_statements(LevelFilter::Trace)
-            .log_slow_statements(LevelFilter::Warn, slow_timeout);
+            // These two take `log::LevelFilter`, the crate's only remaining
+            // `log` use — don't drop the `log` dep to "modernize" onto tracing.
+            .log_statements(log::LevelFilter::Trace)
+            .log_slow_statements(log::LevelFilter::Warn, slow_timeout);
         let conn = SqlitePool::connect_with(opts).await?;
 
         info!("Database `{}` opened", path.display());

--- a/src/database_task.rs
+++ b/src/database_task.rs
@@ -3,8 +3,8 @@ use std::{sync::OnceLock, time::Duration as StdDuration};
 
 use coarsetime::Clock;
 use hashbrown::HashMap;
-use log::{debug, error, info, warn};
 use tokio::time::MissedTickBehavior;
+use tracing::{debug, error, info, warn};
 
 use crate::{
     database::{Database, DeliveryRow, DownloadRow, OriginRow},

--- a/src/deb_mirror.rs
+++ b/src/deb_mirror.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, num::NonZero, path::PathBuf, sync::OnceLock};
 
-use log::debug;
+use tracing::debug;
 
 use crate::{
     config::{CacheHost, ClientHost},

--- a/src/flat_blocklist.rs
+++ b/src/flat_blocklist.rs
@@ -38,8 +38,8 @@ use std::num::NonZero;
 use std::sync::OnceLock;
 
 use hashbrown::{Equivalent, HashSet};
-use log::warn;
 use parking_lot::RwLock;
+use tracing::warn;
 
 use crate::{
     cache_layout::{SUBDIR_FLAT, SUBDIR_FLAT_PREFIX},

--- a/src/guards.rs
+++ b/src/guards.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
-use log::{error, info};
+use tracing::{error, info};
 
 use crate::{
     ContentLength,

--- a/src/http_etag.rs
+++ b/src/http_etag.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use log::warn;
+use tracing::warn;
 
 use crate::xattr_helpers;
 

--- a/src/http_helpers.rs
+++ b/src/http_helpers.rs
@@ -1,8 +1,8 @@
 use std::io::ErrorKind;
 
 use http::{HeaderName, StatusCode};
-use log::trace;
 use tokio::net::TcpStream;
+use tracing::trace;
 
 use crate::{
     APP_NAME, APP_VIA, Never, global_config, http_range::format_http_date, humanfmt::HumanFmt,

--- a/src/http_last_modified.rs
+++ b/src/http_last_modified.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use log::warn;
+use tracing::warn;
 
 use crate::{http_range::HttpDate, xattr_helpers};
 

--- a/src/hyper_conn.rs
+++ b/src/hyper_conn.rs
@@ -19,12 +19,12 @@ use http_body::{Body, Frame, SizeHint};
 use http_body_util::{BodyExt as _, Empty, combinators::BoxBody};
 use hyper::{body::Incoming, server::conn::http1, service::service_fn};
 use hyper_util::{client::legacy::connect::HttpConnector, rt::tokio::TokioIo};
-use log::{debug, error, info, trace, warn};
 #[cfg(feature = "mmap")]
 use memmap2::{Advice, MmapOptions};
 use pin_project::{pin_project, pinned_drop};
 use rand::distr::{Bernoulli, Distribution as _};
 use tokio::io::{AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _};
+use tracing::{debug, error, info, trace, warn};
 
 #[cfg(feature = "mmap")]
 use crate::mmap_body::MmapBody;

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -27,9 +27,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use hashbrown::{Equivalent, HashMap};
-use log::{debug, error, warn};
 use parking_lot::Mutex;
 use tokio::io::AsyncBufRead;
+use tracing::{debug, error, warn};
 
 use crate::error::ErrorReport;
 use crate::limits::LimitedReader;

--- a/src/ktls.rs
+++ b/src/ktls.rs
@@ -9,12 +9,12 @@ use std::io::IoSliceMut;
 use std::os::fd::{AsFd, AsRawFd as _, BorrowedFd};
 use std::sync::OnceLock;
 
-use log::{debug, info, warn};
 use nix::libc;
 use nix::sys::socket::sockopt::TlsCryptoInfo;
 use nix::sys::socket::{self, ControlMessageOwned, MsgFlags, SockaddrStorage, TlsGetRecordType};
 use rustls::ConnectionTrafficSecrets;
 use rustls::crypto::cipher::NONCE_LEN;
+use tracing::{debug, info, warn};
 
 use crate::error::errno_to_io_error;
 use crate::{Never, static_assert, warn_once};

--- a/src/log_once.rs
+++ b/src/log_once.rs
@@ -4,7 +4,7 @@ macro_rules! warn_once {
         static FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
         match FIRED.compare_exchange(false, true, std::sync::atomic::Ordering::Relaxed, std::sync::atomic::Ordering::Relaxed) {
-            Ok(false) => log::warn!($($t)*),
+            Ok(false) => tracing::warn!($($t)*),
             Ok(true) => unreachable!("value must never change from true to false"),
             Err(_) => {}
         }
@@ -16,12 +16,11 @@ macro_rules! warn_once_or_info {
     ($($t:tt)*) => {{
         static FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
-        let level = match FIRED.compare_exchange(false, true, std::sync::atomic::Ordering::Relaxed, std::sync::atomic::Ordering::Relaxed) {
-            Ok(false) => log::Level::Warn,
+        match FIRED.compare_exchange(false, true, std::sync::atomic::Ordering::Relaxed, std::sync::atomic::Ordering::Relaxed) {
+            Ok(false) => tracing::warn!($($t)*),
             Ok(true) => unreachable!("value must never change from true to false"),
-            Err(_) => log::Level::Info,
-        };
-        log::log!(level, $($t)*);
+            Err(_) => tracing::info!($($t)*),
+        }
     }};
 }
 
@@ -30,12 +29,11 @@ macro_rules! warn_once_or_debug {
     ($($t:tt)*) => {{
         static FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
-        let level = match FIRED.compare_exchange(false, true, std::sync::atomic::Ordering::Relaxed, std::sync::atomic::Ordering::Relaxed) {
-            Ok(false) => log::Level::Warn,
+        match FIRED.compare_exchange(false, true, std::sync::atomic::Ordering::Relaxed, std::sync::atomic::Ordering::Relaxed) {
+            Ok(false) => tracing::warn!($($t)*),
             Ok(true) => unreachable!("value must never change from true to false"),
-            Err(_) => log::Level::Debug,
-        };
-        log::log!(level, $($t)*);
+            Err(_) => tracing::debug!($($t)*),
+        }
     }};
 }
 
@@ -45,7 +43,7 @@ macro_rules! info_once {
         static FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
         match FIRED.compare_exchange(false, true, std::sync::atomic::Ordering::Relaxed, std::sync::atomic::Ordering::Relaxed) {
-            Ok(false) => log::info!($($t)*),
+            Ok(false) => tracing::info!($($t)*),
             Ok(true) => unreachable!("value must never change from true to false"),
             Err(_) => {}
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,12 +77,16 @@ use std::{
     fmt::Debug,
     fmt::Display,
     hash::Hash,
+    io::IsTerminal as _,
     net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     num::NonZero,
     os::unix::fs::OpenOptionsExt as _,
     path::{Path, PathBuf},
     pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
@@ -95,14 +99,13 @@ use http::{
 use http_body::{Body, Frame, SizeHint};
 use http_body_util::{BodyExt as _, Full, combinators::BoxBody};
 use hyper_util::client::legacy::connect::HttpConnector;
-use log::{LevelFilter, debug, error, info, trace, warn};
 use pin_project::pin_project;
 #[cfg(feature = "mmap")]
 use rate_checked_body::{MaybeRated, RateCheckedBodyErr};
-use simplelog::{
-    ColorChoice, CombinedLogger, ConfigBuilder, TermLogger, TerminalMode, WriteLogger,
-};
+use time::format_description::well_known::Rfc2822;
 use tokio::runtime::Builder;
+use tracing::{debug, error, info, trace, warn};
+use tracing_subscriber::{Layer as _, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 // TODO: replace usages with ! once stable
 enum Never {}
@@ -561,7 +564,7 @@ struct Cli {
     log_file: Option<config::LogDestination>,
     /// Logging level
     #[arg(short, long, value_name = "SEVERITY")]
-    log_level: Option<LevelFilter>,
+    log_level: Option<tracing::level_filters::LevelFilter>,
     /// Configuration file path
     #[arg(
         short = 'c',
@@ -600,6 +603,7 @@ struct RuntimeDetails {
 struct ReopenableLogFile {
     path: PathBuf,
     file: Arc<parking_lot::Mutex<std::fs::File>>,
+    reopen_requested: Arc<AtomicBool>,
 }
 
 impl ReopenableLogFile {
@@ -612,6 +616,7 @@ impl ReopenableLogFile {
         Ok(Self {
             path: path.to_path_buf(),
             file: Arc::new(parking_lot::Mutex::new(file)),
+            reopen_requested: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -624,17 +629,44 @@ impl ReopenableLogFile {
         *self.file.lock() = file;
         Ok(())
     }
+
+    fn request_reopen(&self) {
+        self.reopen_requested.store(true, Ordering::Relaxed);
+    }
 }
 
 impl std::io::Write for ReopenableLogFile {
-    #[inline]
+    #[expect(
+        clippy::print_stderr,
+        reason = "logger-internal failure, can't log via itself"
+    )]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        /* Deferred here so the swap happens on the single non-blocking worker thread. */
+        if self.reopen_requested.swap(false, Ordering::Relaxed)
+            && let Err(err) = self.reopen()
+        {
+            eprintln!(
+                "Failed to reopen log file `{}`:  {err}",
+                self.path.display()
+            );
+        }
         std::io::Write::write(&mut *self.file.lock(), buf)
     }
 
     #[inline]
     fn flush(&mut self) -> std::io::Result<()> {
         std::io::Write::flush(&mut *self.file.lock())
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct UtcTimer;
+
+impl tracing_subscriber::fmt::time::FormatTime for UtcTimer {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
+        let now = time::OffsetDateTime::now_utc();
+        let formatted = now.format(&Rfc2822).map_err(|_err| std::fmt::Error)?;
+        w.write_str(&formatted)
     }
 }
 
@@ -744,6 +776,8 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         std::process::exit(1);
     }
 
+    tracing_log::LogTracer::init()?;
+
     let (config, cfg_fallback, config_warnings) = config::Config::new(
         &args.config_file,
         args.cache_path.take(),
@@ -752,28 +786,6 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let output_log_level = args.log_level.unwrap_or(config.log_level);
     let output_log_file = args.log_file.as_ref().unwrap_or(&config.log_file);
-
-    let output_log_config = ConfigBuilder::new()
-        .set_time_level(if args.skip_log_timestamp {
-            LevelFilter::Off
-        } else {
-            LevelFilter::Error
-        })
-        .set_thread_level(if output_log_level >= LevelFilter::Debug {
-            LevelFilter::Error
-        } else {
-            LevelFilter::Off
-        })
-        .build();
-
-    let internal_log_config = ConfigBuilder::new()
-        .set_location_level(LevelFilter::Error)
-        .set_level_padding(simplelog::LevelPadding::Right)
-        .set_target_level(LevelFilter::Warn)
-        .set_thread_level(LevelFilter::Error)
-        .set_thread_mode(simplelog::ThreadLogMode::Names)
-        .set_time_format_rfc2822()
-        .build();
 
     LOGSTORE
         .set(logstore::LogStore::new(config.logstore_capacity))
@@ -788,23 +800,42 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .set(parking_lot::RwLock::new(HashMap::new()))
         .expect("Initial set in main() should succeed");
 
-    let internal_logger = WriteLogger::new(
-        LevelFilter::Warn,
-        internal_log_config,
-        LOGSTORE.get().expect("initialized in main()").clone(),
-    );
+    let logstore_handle = LOGSTORE.get().expect("initialized in main()").clone();
+    let internal_layer = tracing_subscriber::fmt::layer()
+        .with_writer(move || logstore_handle.clone())
+        .with_ansi(false)
+        .with_target(true)
+        .with_thread_names(true)
+        .with_level(true)
+        .with_timer(UtcTimer)
+        .with_filter(tracing::level_filters::LevelFilter::WARN);
 
-    match output_log_file {
+    let skip_timestamp = args.skip_log_timestamp;
+    // journald prepends its own timestamp
+    let skip_stderr_timestamp = skip_timestamp || std::env::var_os("JOURNAL_STREAM").is_some();
+    let output_thread_names = output_log_level >= tracing::level_filters::LevelFilter::DEBUG;
+    let stderr_is_tty = std::io::stderr().is_terminal();
+
+    let _log_guard: Option<tracing_appender::non_blocking::WorkerGuard> = match output_log_file {
         config::LogDestination::Console => {
-            CombinedLogger::init(vec![
-                TermLogger::new(
-                    output_log_level,
-                    output_log_config,
-                    TerminalMode::Mixed,
-                    ColorChoice::Auto,
-                ),
-                internal_logger,
-            ])?;
+            let base = tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr as fn() -> std::io::Stderr)
+                .with_ansi(stderr_is_tty)
+                .with_target(false)
+                .with_thread_names(output_thread_names)
+                .with_level(true);
+            let layer = if skip_stderr_timestamp {
+                base.without_time().with_filter(output_log_level).boxed()
+            } else {
+                base.with_timer(UtcTimer)
+                    .with_filter(output_log_level)
+                    .boxed()
+            };
+            tracing_subscriber::registry()
+                .with(internal_layer)
+                .with(layer)
+                .init();
+            None
         }
 
         config::LogDestination::File(path) => {
@@ -830,12 +861,30 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 .set(log_file_handle.clone())
                 .expect("Initial set in main() should succeed");
 
-            CombinedLogger::init(vec![
-                WriteLogger::new(output_log_level, output_log_config, log_file_handle),
-                internal_logger,
-            ])?;
+            let (writer, guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
+                .lossy(false)
+                .finish(log_file_handle);
+
+            let base = tracing_subscriber::fmt::layer()
+                .with_writer(writer)
+                .with_ansi(false)
+                .with_target(false)
+                .with_thread_names(output_thread_names)
+                .with_level(true);
+            let layer = if skip_timestamp {
+                base.without_time().with_filter(output_log_level).boxed()
+            } else {
+                base.with_timer(UtcTimer)
+                    .with_filter(output_log_level)
+                    .boxed()
+            };
+            tracing_subscriber::registry()
+                .with(internal_layer)
+                .with(layer)
+                .init();
+            Some(guard)
         }
-    }
+    };
 
     let config_http_timeout = config.http_timeout;
 

--- a/src/main_loop.rs
+++ b/src/main_loop.rs
@@ -7,8 +7,8 @@ use coarsetime::Instant;
 use futures_util::StreamExt as _;
 use http::{Method, Request, Uri, header::USER_AGENT};
 use http_body_util::Empty;
-use log::{debug, error, info, trace, warn};
 use tokio::{net::TcpListener, signal::unix::SignalKind};
+use tracing::{debug, error, info, trace, warn};
 
 #[cfg(not(feature = "sendfile"))]
 use crate::hyper_conn::handle_hyper_connection;
@@ -355,16 +355,8 @@ pub(crate) async fn main_loop(
             },
             _ = usr1_signal.recv() => {
                 if let Some(output_log_file) = OUTPUT_LOG_FILE.get() {
-                    info!("SIGUSR1 received, reopening log file `{}`...", output_log_file.path.display());
-                    let res = tokio::task::block_in_place(|| output_log_file.reopen());
-                    match res {
-                        Ok(()) => info!("Log file `{}` reopened", output_log_file.path.display()),
-                        Err(err) => error!(
-                            "Failed to reopen log file `{}`:  {}",
-                            output_log_file.path.display(),
-                            ErrorReport(&err)
-                        ),
-                    }
+                    info!("SIGUSR1 received, requesting reopen of log file `{}`...", output_log_file.path.display());
+                    output_log_file.request_reopen();
                 } else {
                     info!("Ignoring SIGUSR1 because logging is set to console");
                 }

--- a/src/mmap_body.rs
+++ b/src/mmap_body.rs
@@ -1,8 +1,8 @@
 use std::{convert::Infallible, pin::Pin, sync::Arc, task::Poll::Ready};
 
 use http_body::{Body, Frame, SizeHint};
-use log::info;
 use memmap2::Mmap;
+use tracing::info;
 
 use crate::{
     cache_layout::{CachedFlavor, ConnectionDetails},

--- a/src/rate_checker.rs
+++ b/src/rate_checker.rs
@@ -1,7 +1,7 @@
 use std::num::NonZero;
 
 use coarsetime::{Duration, Instant};
-use log::debug;
+use tracing::debug;
 
 use crate::{humanfmt::HumanFmt, metrics, ringbuffer::SumRingBuffer};
 

--- a/src/request_dispatch.rs
+++ b/src/request_dispatch.rs
@@ -30,7 +30,7 @@
 use std::{cell::LazyCell, num::NonZero};
 
 use http::StatusCode;
-use log::{info, trace};
+use tracing::{info, trace};
 
 use crate::{
     ClientInfo,

--- a/src/secure_vec.rs
+++ b/src/secure_vec.rs
@@ -5,8 +5,8 @@
 
 use std::{num::NonZero, sync::LazyLock};
 
-use log::{debug, error};
 use nix::libc;
+use tracing::{debug, error};
 
 use crate::warn_once_or_debug;
 

--- a/src/sendfile_conn.rs
+++ b/src/sendfile_conn.rs
@@ -13,12 +13,12 @@ use http::{
     StatusCode,
     header::{CONNECTION, HOST, IF_MODIFIED_SINCE, IF_NONE_MATCH, IF_RANGE, RANGE},
 };
-use log::{debug, error, info, trace, warn};
 use nix::sys::sendfile::sendfile;
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     net::TcpStream,
 };
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     APP_NAME, AppState, ClientInfo, ContentLength, Never, VOLATILE_CACHE_MAX_AGE,

--- a/src/splice_conn.rs
+++ b/src/splice_conn.rs
@@ -21,12 +21,12 @@ use http::{
         TRANSFER_ENCODING,
     },
 };
-use log::{debug, error, info, trace, warn};
 use nix::fcntl::{SpliceFFlags, splice, tee};
 use tokio::{
     io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _, Interest, ReadBuf},
     net::{TcpStream, unix::pipe},
 };
+use tracing::{debug, error, info, trace, warn};
 
 use crate::cache_layout::{CachedFlavor, ConnectionDetails, SUBDIR_TMP};
 use crate::cache_quota::QuotaExceeded;

--- a/src/task_cache_scan.rs
+++ b/src/task_cache_scan.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, path::Path};
 
 use hashbrown::HashMap;
-use log::{debug, error, info, trace, warn};
 use tokio::fs::DirEntry;
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     cache_layout::{KNOWN_MIRROR_SUBDIRS, SUBDIR_FLAT, SUBDIR_FLAT_BYHASH, SUBDIR_TMP},

--- a/src/task_setup.rs
+++ b/src/task_setup.rs
@@ -1,7 +1,7 @@
 use std::os::unix::fs::OpenOptionsExt as _;
 
 use anyhow::Context as _;
-use log::{debug, error, info, warn};
+use tracing::{debug, error, info, warn};
 use xattr::FileExt as _;
 
 use crate::{cache_layout::SUBDIR_TMP, global_config};

--- a/src/tcp_cork_guard.rs
+++ b/src/tcp_cork_guard.rs
@@ -1,7 +1,7 @@
 use std::{io::ErrorKind, os::fd::AsRawFd as _};
 
-use log::warn;
 use tokio::net::TcpStream;
+use tracing::warn;
 
 use crate::{static_assert, warn_once_or_debug};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,8 +3,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use log::{debug, error, info, warn};
 use rand::{RngExt as _, distr::Alphanumeric, rngs::SmallRng};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     Never,

--- a/src/web_interface.rs
+++ b/src/web_interface.rs
@@ -20,8 +20,8 @@ use http::{
 };
 use http_body::{Body, Frame, SizeHint};
 use http_body_util::{BodyExt as _, Full, combinators::BoxBody};
-use log::{debug, error, trace, warn};
 use time::{OffsetDateTime, format_description::FormatItem, macros::format_description};
+use tracing::{debug, error, trace, warn};
 
 use crate::{
     APP_NAME, APP_VERSION, AppState, LOGSTORE, ProxyCacheBody, RUNTIMEDETAILS, RuntimeDetails,

--- a/src/xattr_helpers.rs
+++ b/src/xattr_helpers.rs
@@ -10,8 +10,8 @@
 
 use std::{num::ParseIntError, path::Path};
 
-use log::warn;
 use nix::libc;
+use tracing::warn;
 use xattr::FileExt as _;
 
 /// Wrapper to implement [`xattr::FileExt`] for [`tokio::fs::File`].


### PR DESCRIPTION
simplelog wrote each log record synchronously through a Mutex-guarded file handle on the calling tokio worker, parking the worker on disk I/O under load. Switch the logger stack to tracing-subscriber and route file output through tracing-appender's NonBlocking writer so log writes happen on a dedicated thread; SIGUSR1 still atomically swaps the underlying file via the existing ReopenableLogFile.

Console output now goes uniformly to stderr (was info->stdout, warn/error->stderr); integration test readiness probes follow.